### PR TITLE
Fixes error `attempt to insert nil object from objects[2] was thrown while invoking readDir on target`

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -158,9 +158,9 @@ var RNFS = {
   downloadFile(fromUrl, toFile, begin, progress) {
     var jobId = getJobId();
     var subscriptions = [];
-    var beginListener = begin || (info) => {
+    var beginListener = begin || ((info) => {
       console.log('Download begun:', info);
-    };
+    });
 
     if (begin) {
       subscriptions.push(NativeAppEventEmitter.addListener('DownloadBegin-' + jobId, begin));


### PR DESCRIPTION
This error happens when trying to read a file or directory for which the user doesn't have permissions. Doing this will throw the error below. This pull request skips over any file that throws an error when trying to read the attributes. Also skips over any dotfile found on the directory.

![simulator_screen_shot_apr_13 _2016 _9 35 07_am](https://cloud.githubusercontent.com/assets/37972/14577418/67d6ad2c-0339-11e6-8b9f-52a93a71c243.png)
