### PR TITLE
fix: workable path to external directory in android

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -334,7 +334,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     constants.put(NSDocumentDirectory, 0);
     constants.put(NSDocumentDirectoryPath, this.getReactApplicationContext().getFilesDir().getAbsolutePath());
     constants.put(NSTemporaryDirectoryPath, null);
-    File externalDirectory = this.getReactApplicationContext().getExternalFilesDir(null);
+    File externalDirectory = Environment.getExternalStorageDirectory();
     if (externalDirectory != null) {
         constants.put(NSExternalDirectoryPath, externalDirectory.getAbsolutePath());
     } else {


### PR DESCRIPTION
I tried to get access to the files/directories inside the external storage in Android like this: 

```
RNFS.readDir(RNFS.ExternalDirectoryPath)
        .then((result) => {
        console.log('GOT RESULT', result);
            .catch(console.log)
});
```

I got back an empty array, so I checked out how `ExternalDirectoryPath` was defined, which was: 
 `File externalDirectory = this.getReactApplicationContext().getExternalFilesDir(null);` 

The official documentation for [Android](https://developer.android.com/reference/android/os/Environment.html#getExternalStorageDirectory%28%29) has a different way of accessing the external directory, which is : `Environment.getExternalStorageDirectory()`. I tried this fix on Nexus 4, Moto E2, Nexus 6p and I am now able to get back an array of objects showing files and directories.

This pull request changes the definition of `ExternalDirectoryPath`.
