### PR TITLE
Closes #46 - 'RCTBridgeModule.h' file not found error

### DIFF
--- a/RNFSManager.h
+++ b/RNFSManager.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 Johannes Lumpe. All rights reserved.
 //
 
-#import <React/RCTBridgeModule.h>
-#import <React/RCTLog.h>
+#import "RCTBridgeModule.h"
+#import "RCTLog.h"
 
 @interface RNFSManager : NSObject <RCTBridgeModule>
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -7,11 +7,11 @@
 //
 
 #import "RNFSManager.h"
-#import <React/RCTBridge.h>
+#import "RCTBridge.h"
 #import "NSArray+Map.h"
 #import "Downloader.h"
 #import "Uploader.h"
-#import <React/RCTEventDispatcher.h>
+#import "RCTEventDispatcher.h"
 #import <CommonCrypto/CommonDigest.h>
 
 @interface RNFSManager()


### PR DESCRIPTION
This PR for the fix of issue: https://github.com/johanneslumpe/react-native-fs/issues/46