### PR TITLE
set response statuscode even if content length is zero

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -72,6 +72,10 @@
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
+  NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)downloadTask.response;
+  if (!_statusCode) {
+    _statusCode = [NSNumber numberWithLong:httpResponse.statusCode];
+  }
   NSURL *destURL = [NSURL fileURLWithPath:_params.toFile];
   NSFileManager *fm = [NSFileManager defaultManager];
   NSError *error = nil;


### PR DESCRIPTION
Hi!

We achieved an issue when response content length was zero, but statuscode 200 and downloadTask didWriteData was never called.

So idea is to initialise status code if it wasn't set in didFinishDownloadingToURL method.

Otherwise we received crash in completeCallback (RNFSManager.m)

Waiting for your review ^_^