### PR TITLE
Handle 307/308 redirect

### DIFF
--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -67,7 +67,9 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         statusCode != HttpURLConnection.HTTP_OK &&
         (
           statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
-          statusCode == HttpURLConnection.HTTP_MOVED_TEMP
+          statusCode == HttpURLConnection.HTTP_MOVED_TEMP ||
+          statusCode == 307 ||
+          statusCode == 308
         )
       );
 


### PR DESCRIPTION
There isn't a constant for these values in the API, so we just write the literal value.