### PR TITLE
[iOS] Cancelling download causes promise rejection to be called twice

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -102,7 +102,9 @@
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-  return error ? _params.errorCallback(error) : nil;
+  if (error && error.code != -999) {
+    _params.errorCallback(error);
+  }
 }
 
 - (void)stopDownload

--- a/Downloader.m
+++ b/Downloader.m
@@ -100,9 +100,9 @@
   return _params.completeCallback(_statusCode, _bytesWritten);
 }
 
-- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionTask *)downloadTask didCompleteWithError:(NSError *)error
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-  return _params.errorCallback(error);
+  return error ? _params.errorCallback(error) : nil;
 }
 
 - (void)stopDownload


### PR DESCRIPTION
If you cancel a download task the promise rejection is called twice by the delegate. This checks for -999 status code which indicates the download has been cancelled