### PR TITLE
Add created and modified dates to `ReadDirItem`

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -31,6 +31,8 @@ type MkdirOptions = {
 };
 
 type ReadDirItem = {
+  created: date;     // The creation date of the file (iOS only)
+  modified: date;     // The last modified date of the file
   name: string;     // The name of the item
   path: string;     // The absolute path to the item
   size: string;     // Size in bytes
@@ -159,6 +161,8 @@ function readFileGeneric(filepath: string, encodingOrOptions:?string, command: F
 function readDirGeneric(dirpath: string, command: Function) {
   return command(normalizeFilePath(dirpath)).then(files => {
     return files.map(file => ({
+      created: file.created && new Date(file.created),
+      modified: new Date(file.modified),
       name: file.name,
       path: file.path,
       size: file.size,

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ The returned promise resolves with an array of objects with the following proper
 
 ```
 type ReadDirItem = {
+  created: date;     // The creation date of the file (iOS only)
+  modified: date;     // The last modified date of the file
   name: string;     // The name of the item
   path: string;     // The absolute path to the item
   size: string;     // Size in bytes

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -52,6 +52,8 @@ RCT_EXPORT_METHOD(readDir:(NSString *)dirPath
     NSDictionary *attributes = [fileManager attributesOfItemAtPath:path error:nil];
 
     return @{
+             @"created": [attributes objectForKey:NSFileCreationDate],
+             @"modified": [attributes objectForKey:NSFileModificationDate],
              @"name": obj,
              @"path": path,
              @"size": [attributes objectForKey:NSFileSize],

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -259,6 +259,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       for (File childFile : files) {
         WritableMap fileMap = Arguments.createMap();
 
+        fileMap.putString("modified", childFile.lastModified());
         fileMap.putString("name", childFile.getName());
         fileMap.putString("path", childFile.getAbsolutePath());
         fileMap.putInt("size", (int)childFile.length());


### PR DESCRIPTION
Found myself needing this functionality when scanning a directory for file contents using `readDir`. The `created` date is only available on iOS but the `modified` date is available for both platforms.

Related issue: #253

Disclaimer: I'm not an Android developer and only a recent React Native developer so if there's a better way to accomplish this please point it out!