### PR TITLE
Update the android SDK version to 25

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
When using the current android studio with the current SDKs you have the problem that your app is on version 25 and you can not create a APK without adjusting the buildToolsVersion in the build.gradle