### PR TITLE
Added write function for performing random access writes

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -339,6 +339,38 @@ var RNFS = {
     return RNFSManager.appendFile(normalizeFilePath(filepath), b64);
   },
 
+  write(filepath: string, contents: string, position?: number, encodingOrOptions?: any): Promise<void> {
+    var b64;
+
+    var options = {
+      encoding: 'utf8'
+    };
+
+    if (encodingOrOptions) {
+      if (typeof encodingOrOptions === 'string') {
+        options.encoding = encodingOrOptions;
+      } else if (typeof encodingOrOptions === 'object') {
+        options = encodingOrOptions;
+      }
+    }
+
+    if (options.encoding === 'utf8') {
+      b64 = base64.encode(utf8.encode(contents));
+    } else if (options.encoding === 'ascii') {
+      b64 = base64.encode(contents);
+    } else if (options.encoding === 'base64') {
+      b64 = contents;
+    } else {
+      throw new Error('Invalid encoding type "' + options.encoding + '"');
+    }
+
+    if (position === undefined) {
+      position = -1;
+    }
+
+    return RNFSManager.write(normalizeFilePath(filepath), b64, position).then(() => void 0);
+  },
+
   downloadFile(options: DownloadFileOptions): { jobId: number, promise: Promise<DownloadResult> } {
     if (typeof options !== 'object') throw new Error('downloadFile: Invalid value for argument `options`');
     if (typeof options.fromUrl !== 'string') throw new Error('downloadFile: Invalid value for property `fromUrl`');

--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ Write the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `
 
 Append the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`.
 
+### `write(filepath: string, contents: string, position?: number, encoding?: string): Promise<void>`
+
+Write the `contents` to `filepath` at the given random access position. When `position` is `undefined` or `-1` the contents is appended to the end of the file. `encoding` can be one of `utf8` (default), `ascii`, `base64`.
+
 ### `moveFile(filepath: string, destPath: string): Promise<void>`
 
 Moves the file located at `filepath` to `destPath`. This is more performant than reading and then re-writing the file data because the move is done natively and the data doesn't have to be copied or cross the bridge.

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.util.HashMap;
@@ -79,6 +80,29 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       FileOutputStream outputStream = new FileOutputStream(filepath, true);
       outputStream.write(bytes);
       outputStream.close();
+
+      promise.resolve(null);
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      reject(promise, filepath, ex);
+    }
+  }
+
+  @ReactMethod
+  public void write(String filepath, String base64Content, int position, Promise promise) {
+    try {
+      byte[] bytes = Base64.decode(base64Content, Base64.DEFAULT);
+
+      if (position < 0) {
+        FileOutputStream outputStream = new FileOutputStream(filepath, true);
+        outputStream.write(bytes);
+        outputStream.close();
+      } else {
+        RandomAccessFile file = new RandomAccessFile(filepath, "rw");
+        file.seek(position);
+        file.write(bytes);
+        file.close();
+      }
 
       promise.resolve(null);
     } catch (Exception ex) {


### PR DESCRIPTION
This pull requests adds support for random access writes, as discussed in #250.
It follows the official node-js FS api, signature:
https://nodejs.org/api/fs.html#fs_fs_write_fd_string_position_encoding_callback

### `write(filepath: string, contents: string, position?: number, encoding?: string): Promise<void>`

Write the `contents` to `filepath` at the given random access position. When `position` is `undefined` or `-1` the contents is appended to the end of the file. `encoding` can be one of `utf8` (default), `ascii`, `base64`.
