### PR TITLE
Fix flowtype of date object in ReadDirItem

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -31,8 +31,8 @@ type MkdirOptions = {
 };
 
 type ReadDirItem = {
-  created: date;     // The creation date of the file (iOS only)
-  modified: date;     // The last modified date of the file
+  created: ?Date;    // The creation date of the file (iOS only)
+  modified: Date;   // The last modified date of the file
   name: string;     // The name of the item
   path: string;     // The absolute path to the item
   size: string;     // Size in bytes
@@ -276,7 +276,7 @@ var RNFS = {
 
   // iOS only
   // Copies fotos from asset-library (camera-roll) to a specific location
-  // with a given width or height 
+  // with a given width or height
   // @see: https://developer.apple.com/reference/photos/phimagemanager/1616964-requestimageforasset
   copyAssetsFileIOS(imageUri: string, destPath: string, width: number, height: number,
     scale : number = 1.0, compression : number = 1.0, resizeMode : string = 'contain'  ): Promise<string> {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Native filesystem access for react-native",
   "main": "FS.common.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "flow": "flow; test $? -eq 0 -o $? -eq 2"
   },
   "repository": {
     "type": "git",
@@ -28,7 +29,7 @@
     "utf8": "^2.1.1"
   },
   "devDependencies": {
-    "flow-bin": "0.27.0",
+    "flow-bin": "0.28.0",
     "react": "^15.4.2",
     "react-native": "^0.40.0"
   }


### PR DESCRIPTION
### Summary

On react-native projects that use flow (on by default), this started showing up as an invalid type.

This commit also upgrades flow bin to match .flowconfig version and adds a npm script to run flow check.

Resolves #289

### Test plan

1. Run `npm run flow`, no longer see error for undefined `date` type.
2. Import into another project locally, no longer see that error.