### PR TITLE
Remove createJSModules from package

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSPackage.java
+++ b/android/src/main/java/com/rnfs/RNFSPackage.java
@@ -18,11 +18,6 @@ public class RNFSPackage implements ReactPackage {
   }
 
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Arrays.<ViewManager>asList();
   }


### PR DESCRIPTION
createJSModules is now no longer required https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8

This PR is currently only compatible with RN master.