### PR TITLE
read method similar to the node.js fs.read method (iOS and Android)

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -260,6 +260,36 @@ var RNFS = {
     return readFileGeneric(filepath, encodingOrOptions, RNFSManager.readFile);
   },
 
+  read(filepath: string, length = 0, position = 0, encodingOrOptions?: any): Promise<string> {
+  	var options = {
+      encoding: 'utf8'
+    };
+
+    if (encodingOrOptions) {
+      if (typeof encodingOrOptions === 'string') {
+        options.encoding = encodingOrOptions;
+      } else if (typeof encodingOrOptions === 'object') {
+        options = encodingOrOptions;
+      }
+    }
+
+    return RNFSManager.read(normalizeFilePath(filepath), length, position).then((b64) => {
+      var contents;
+
+      if (options.encoding === 'utf8') {
+        contents = utf8.decode(base64.decode(b64));
+      } else if (options.encoding === 'ascii') {
+        contents = base64.decode(b64);
+      } else if (options.encoding === 'base64') {
+        contents = b64;
+      } else {
+        throw new Error('Invalid encoding type "' + String(options.encoding) + '"');
+      }
+
+      return contents;
+    });
+  },
+
   // Android only
   readFileAssets(filepath: string, encodingOrOptions?: any): Promise<string> {
     if (!RNFSManager.readFileAssets) {

--- a/README.md
+++ b/README.md
@@ -363,6 +363,12 @@ Reads the file at `path` and return contents. `encoding` can be one of `utf8` (d
 
 Note: you will take quite a performance hit if you are reading big files
 
+### `read(filepath: string, length = 0, position = 0, encodingOrOptions?: any): Promise<string>`
+
+Reads length bits from the given position of the file and returns contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+
+Note: reading big files piece by piece using this method may be useful in terms of performance.
+
 ### `readFileAssets(filepath:string, encoding?: string): Promise<string>`
 
 Reads the file at `path` in the Android app's assets folder and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Note: you will take quite a performance hit if you are reading big files
 
 ### `read(filepath: string, length = 0, position = 0, encodingOrOptions?: any): Promise<string>`
 
-Reads length bits from the given position of the file and returns contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+Reads `length` bytes from the given `position` of the file at `path` and returns contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
 
 Note: reading big files piece by piece using this method may be useful in terms of performance.
 

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -151,6 +151,35 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void read(String filepath, int length, int position, Promise promise){
+    try {
+      File file = new File(filepath);
+
+      if (file.isDirectory()) {
+        rejectFileIsDirectory(promise);
+        return;
+      }
+
+      if (!file.exists()) {
+        rejectFileNotFound(promise, filepath);
+        return;
+      }
+
+      FileInputStream inputStream = new FileInputStream(filepath);
+      byte[] buffer = new byte[length];
+      inputStream.skip(position);
+      inputStream.read(buffer,0,length);
+
+      String base64Content = Base64.encodeToString(buffer, Base64.NO_WRAP);
+
+      promise.resolve(base64Content);
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        reject(promise, filepath, ex);
+    }
+  }
+
+  @ReactMethod
   public void readFileAssets(String filepath, Promise promise) {
     InputStream stream = null;
     try {


### PR DESCRIPTION
I need to read files piece by piece, in other words chunk by chunk, in my project. So current methods such as `readFile` method DO NOT meet my requirements. I wrote a `read` method for my requirement. I think other developers may need similar functionality.

`read(filepath: string, length = 0, position = 0, encodingOrOptions?: any): Promise<string>`

I tried to use a method signature similar to the fs.read method of Node.js
But I think `buffer` and `offset` params are not suitable for our case. 
[reference to fs.read Node.js](https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_read_fd_buffer_offset_length_position_callback)

I took the iOS implementation from an old pull request.
So credits for iOS implementation goes to @macdabby 

#160
#153  