### PR TITLE
Update `compileSdkVersion` to 26 and `buildToolsVersion` to 26.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.0"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Minimum required for up-to-date apps is 25. This saves people from getting the following error and having to fix it manually.

![screenshot 2017-07-19 12 59 48](https://user-images.githubusercontent.com/180819/28384493-2f5790c0-6c82-11e7-9e5b-2e8c34591d86.png)