### PR TITLE
Add `createJSModules()` back to RNFSPackage.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.0"
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/com/rnfs/RNFSPackage.java
+++ b/android/src/main/java/com/rnfs/RNFSPackage.java
@@ -16,6 +16,11 @@ public class RNFSPackage implements ReactPackage {
     modules.add(new RNFSManager(reactContext));
     return modules;
   }
+  
+  @Override
+  public List<Class<? extends JavaScriptModule>> createJSModules() {
+    return Collections.emptyList();
+  }
 
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {


### PR DESCRIPTION
This causes an error for me on react-native 0.46.4.

Fixes #317.