### PR TITLE
Made downlaodFile resumable

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -4,6 +4,7 @@ typedef void (^DownloadCompleteCallback)(NSNumber*, NSNumber*);
 typedef void (^ErrorCallback)(NSError*);
 typedef void (^BeginCallback)(NSNumber*, NSNumber*, NSDictionary*);
 typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
+typedef void (^ResumableCallback)();
 
 @interface RNFSDownloadParams : NSObject
 
@@ -14,6 +15,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 @property (copy) ErrorCallback errorCallback;                 // Something went wrong
 @property (copy) BeginCallback beginCallback;                 // Download has started (headers received)
 @property (copy) ProgressCallback progressCallback;           // Download is progressing
+@property (copy) ResumableCallback resumableCallback;         // Download has stopped but is resumable
 @property        bool background;                             // Whether to continue download when app is in background
 @property (copy) NSNumber* progressDivider;
 
@@ -24,5 +26,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 
 - (void)downloadFile:(RNFSDownloadParams*)params;
 - (void)stopDownload;
+- (void)resumeDownload;
+- (BOOL)isResumable;
 
 @end

--- a/FS.common.js
+++ b/FS.common.js
@@ -212,6 +212,14 @@ var RNFS = {
     RNFSManager.stopDownload(jobId);
   },
 
+  resumeDownload(jobId: number): void {
+      RNFSManager.resumeDownload(jobId);
+  },
+
+  isResumable(jobId: number): Promise<bool> {
+      return RNFSManager.isResumable(jobId);
+  },
+
   stopUpload(jobId: number): void {
     RNFSManager.stopUpload(jobId);
   },
@@ -426,6 +434,10 @@ var RNFS = {
 
     if (options.progress) {
       subscriptions.push(NativeAppEventEmitter.addListener('DownloadProgress-' + jobId, options.progress));
+    }
+
+    if (options.resumable) {
+      subscriptions.push(NativeAppEventEmitter.addListener('DownloadResumable-' + jobId, options.resumable));
     }
 
     var bridgeOptions = {

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ type DownloadFileOptions = {
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;
-  resumable?: () => void;
+  resumable?: () => void;    // only supported on iOS yet
   connectionTimeout?: number // only supported on Android yet
   readTimeout?: number       // only supported on Android yet
 };
@@ -509,17 +509,17 @@ If `progressDivider` = 0, you will receive all `progressCallback` calls, default
                            the fetch interval in `didFinishLaunchingWithOptions`. The `performFetchWithCompletionHandler`
                            callback is handled by RNFS.
 
-If `options.resumable` is provided, it will be invoked when the download has stopped and and can be resumed using `resumeDownload()`.
+(IOS only): If `options.resumable` is provided, it will be invoked when the download has stopped and and can be resumed using `resumeDownload()`.
 
 ### `stopDownload(jobId: number): void`
 
 Abort the current download job with this ID. The partial file will remain on the filesystem.
 
-### `resumeDownload(jobId: number): void`
+### (iOS only) `resumeDownload(jobId: number): void`
 
 Resume the current download job with this ID.
 
-### `isResumable(jobId: number): Promise<bool>`
+### (iOS only) `isResumable(jobId: number): Promise<bool>`
 
 Check if the the download job with this ID is resumable with `resumeDownload()`.
 

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ type DownloadFileOptions = {
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;
+  resumable?: () => void;
   connectionTimeout?: number // only supported on Android yet
   readTimeout?: number       // only supported on Android yet
 };
@@ -508,10 +509,27 @@ If `progressDivider` = 0, you will receive all `progressCallback` calls, default
                            the fetch interval in `didFinishLaunchingWithOptions`. The `performFetchWithCompletionHandler`
                            callback is handled by RNFS.
 
+If `options.resumable` is provided, it will be invoked when the download has stopped and and can be resumed using `resumeDownload()`.
 
 ### `stopDownload(jobId: number): void`
 
 Abort the current download job with this ID. The partial file will remain on the filesystem.
+
+### `resumeDownload(jobId: number): void`
+
+Resume the current download job with this ID.
+
+### `isResumable(jobId: number): Promise<bool>`
+
+Check if the the download job with this ID is resumable with `resumeDownload()`.
+
+Example:
+
+```
+if (await RNFS.isResumable(jobId) {
+    RNFS.resumeDownload(jobId)
+}
+```
 
 ### (iOS only) `uploadFiles(options: UploadFileOptions): { jobId: number, promise: Promise<UploadResult> }`
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -454,6 +454,10 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
                                                         @"contentLength": contentLength,
                                                         @"bytesWritten": bytesWritten}];
   };
+    
+    params.resumableCallback = ^() {
+        [self.bridge.eventDispatcher sendAppEventWithName:[NSString stringWithFormat:@"DownloadResumable-%@", jobId] body:nil];
+    };
 
   if (!self.downloaders) self.downloaders = [[NSMutableDictionary alloc] init];
 
@@ -471,6 +475,29 @@ RCT_EXPORT_METHOD(stopDownload:(nonnull NSNumber *)jobId)
   if (downloader != nil) {
     [downloader stopDownload];
   }
+}
+
+RCT_EXPORT_METHOD(resumeDownload:(nonnull NSNumber *)jobId)
+{
+    RNFSDownloader* downloader = [self.downloaders objectForKey:[jobId stringValue]];
+    
+    if (downloader != nil) {
+        [downloader resumeDownload];
+    }
+}
+
+RCT_EXPORT_METHOD(isResumable:(nonnull NSNumber *)jobId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+)
+{
+    RNFSDownloader* downloader = [self.downloaders objectForKey:[jobId stringValue]];
+    
+    if (downloader != nil) {
+        resolve([NSNumber numberWithBool:[downloader isResumable]]);
+    } else {
+        resolve([NSNumber numberWithBool:NO]);
+    }
 }
 
 RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options


### PR DESCRIPTION
Hi guys,

1st of all, great lib, I love it.
2nd, I needed the ability to pause and resume downloads and even resume download that failed due to connectivity loss but are resumable.
So I've made the changes.

I changes the flow a bit, so now when `didCompleteWithError` is called
we check if the error contains `resumeData`, if it does we call the `resumable` callback instead of rejecting the promise.
`stopDownload` should always generate a `resumeData` making it more of a pause function.

 I hope you like it!