### PR TITLE
Fixing broken mTime on Android 5.x

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -312,7 +312,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       for (File childFile : files) {
         WritableMap fileMap = Arguments.createMap();
 
-        fileMap.putInt("mtime", (int)childFile.lastModified());
+        fileMap.putDouble("mtime", (double)childFile.lastModified()/1000);
         fileMap.putString("name", childFile.getName());
         fileMap.putString("path", childFile.getAbsolutePath());
         fileMap.putInt("size", (int)childFile.length());


### PR DESCRIPTION
Mtime was broken - int conversion damaged Timestamp. So i changed it to putDouble which results in appropriate Timestamps.