### PR TITLE
Fix flowtype errors for read()

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -260,7 +260,7 @@ var RNFS = {
     return readFileGeneric(filepath, encodingOrOptions, RNFSManager.readFile);
   },
 
-  read(filepath: string, length = 0, position = 0, encodingOrOptions?: any): Promise<string> {
+  read(filepath: string, length: number = 0, position: number = 0, encodingOrOptions?: any): Promise<string> {
   	var options = {
       encoding: 'utf8'
     };


### PR DESCRIPTION
This was failing on flow 0.49.1 (default for RN 0.47.1).