### PR TITLE
(iOS only) Resumable downloads and better background downloads handling

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -24,7 +24,7 @@ typedef void (^ResumableCallback)();
 
 @interface RNFSDownloader : NSObject <NSURLSessionDelegate, NSURLSessionDownloadDelegate>
 
-- (void)downloadFile:(RNFSDownloadParams*)params;
+- (NSString *)downloadFile:(RNFSDownloadParams*)params;
 - (void)stopDownload;
 - (void)resumeDownload;
 - (BOOL)isResumable;

--- a/Downloader.h
+++ b/Downloader.h
@@ -4,6 +4,7 @@ typedef void (^DownloadCompleteCallback)(NSNumber*, NSNumber*);
 typedef void (^ErrorCallback)(NSError*);
 typedef void (^BeginCallback)(NSNumber*, NSNumber*, NSDictionary*);
 typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
+typedef void (^ResumableCallback)();
 
 @interface RNFSDownloadParams : NSObject
 
@@ -14,6 +15,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 @property (copy) ErrorCallback errorCallback;                 // Something went wrong
 @property (copy) BeginCallback beginCallback;                 // Download has started (headers received)
 @property (copy) ProgressCallback progressCallback;           // Download is progressing
+@property (copy) ResumableCallback resumableCallback;         // Download has stopped but is resumable
 @property        bool background;                             // Whether to continue download when app is in background
 @property (copy) NSNumber* progressDivider;
 
@@ -24,5 +26,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 
 - (void)downloadFile:(RNFSDownloadParams*)params;
 - (void)stopDownload;
+- (void)resumeDownload;
+- (BOOL)isResumable;
 
 @end

--- a/Downloader.m
+++ b/Downloader.m
@@ -22,9 +22,11 @@
 
 @implementation RNFSDownloader
 
-- (void)downloadFile:(RNFSDownloadParams*)params
+- (NSString *)downloadFile:(RNFSDownloadParams*)params
 {
-  _params = params;
+    NSString *uuid = nil;
+    
+    _params = params;
 
   _bytesWritten = 0;
 
@@ -37,14 +39,15 @@
     NSError* error = [NSError errorWithDomain:@"Downloader" code:NSURLErrorFileDoesNotExist
                               userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"Failed to create target file at path: %@", _params.toFile]}];
 
-    return _params.errorCallback(error);
+    _params.errorCallback(error);
+      return nil;
   } else {
     [_fileHandle closeFile];
   }
 
   NSURLSessionConfiguration *config;
   if (_params.background) {
-    NSString *uuid = [[NSUUID UUID] UUIDString];
+    uuid = [[NSUUID UUID] UUIDString];
     config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:uuid];
   } else {
     config = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -55,6 +58,8 @@
   _session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
   _task = [_session downloadTaskWithURL:url];
   [_task resume];
+    
+    return uuid;
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite

--- a/FS.common.js
+++ b/FS.common.js
@@ -225,7 +225,7 @@ var RNFS = {
   },
 
   completeHandlerIOS(jobId: number): void {
-    RNFSManager.completeHandlerIOS(jobId);
+    return RNFSManager.completeHandlerIOS(jobId);
   },
 
   readDir(dirpath: string): Promise<ReadDirItem[]> {

--- a/FS.common.js
+++ b/FS.common.js
@@ -224,6 +224,10 @@ var RNFS = {
     RNFSManager.stopUpload(jobId);
   },
 
+  completeHandlerIOS(jobId: number): void {
+    RNFSManager.completeHandlerIOS(jobId);
+  },
+
   readDir(dirpath: string): Promise<ReadDirItem[]> {
     return readDirGeneric(dirpath, RNFSManager.readDir);
   },

--- a/FS.common.js
+++ b/FS.common.js
@@ -212,6 +212,14 @@ var RNFS = {
     RNFSManager.stopDownload(jobId);
   },
 
+  resumeDownload(jobId: number): void {
+      RNFSManager.resumeDownload(jobId);
+  },
+
+  isResumable(jobId: number): Promise<bool> {
+      return RNFSManager.isResumable(jobId);
+  },
+
   stopUpload(jobId: number): void {
     RNFSManager.stopUpload(jobId);
   },
@@ -426,6 +434,10 @@ var RNFS = {
 
     if (options.progress) {
       subscriptions.push(NativeAppEventEmitter.addListener('DownloadProgress-' + jobId, options.progress));
+    }
+
+    if (options.resumable) {
+      subscriptions.push(NativeAppEventEmitter.addListener('DownloadResumable-' + jobId, options.resumable));
     }
 
     var bridgeOptions = {

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ type DownloadFileOptions = {
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;
-  resumable?: () => void;
+  resumable?: () => void;    // only supported on iOS yet
   connectionTimeout?: number // only supported on Android yet
   readTimeout?: number       // only supported on Android yet
 };
@@ -509,17 +509,17 @@ If `progressDivider` = 0, you will receive all `progressCallback` calls, default
                            the fetch interval in `didFinishLaunchingWithOptions`. The `performFetchWithCompletionHandler`
                            callback is handled by RNFS.
 
-If `options.resumable` is provided, it will be invoked when the download has stopped and and can be resumed using `resumeDownload()`.
+(IOS only): If `options.resumable` is provided, it will be invoked when the download has stopped and and can be resumed using `resumeDownload()`.
 
 ### `stopDownload(jobId: number): void`
 
 Abort the current download job with this ID. The partial file will remain on the filesystem.
 
-### `resumeDownload(jobId: number): void`
+### (iOS only) `resumeDownload(jobId: number): void`
 
 Resume the current download job with this ID.
 
-### `isResumable(jobId: number): Promise<bool>`
+### (iOS only) `isResumable(jobId: number): Promise<bool>`
 
 Check if the the download job with this ID is resumable with `resumeDownload()`.
 

--- a/README.md
+++ b/README.md
@@ -503,11 +503,7 @@ Use it for performance issues.
 If `progressDivider` = 0, you will receive all `progressCallback` calls, default value is 0.
 
 (IOS only): `options.background` (`Boolean`) - Whether to continue downloads when the app is not focused (default: `false`)
-                           This option is currently only available for iOS, and you must [enable
-                           background fetch](https://www.objc.io/issues/5-ios7/multitasking/#background-fetch<Paste>)
-                           for your project in XCode. You only need to enable background fetch in `Info.plist` and set
-                           the fetch interval in `didFinishLaunchingWithOptions`. The `performFetchWithCompletionHandler`
-                           callback is handled by RNFS.
+                           This option is currently only available for iOS, see the [Background Downloads Tutorial (iOS)](#background-downloads-tutorial-ios) section.
 
 (IOS only): If `options.resumable` is provided, it will be invoked when the download has stopped and and can be resumed using `resumeDownload()`.
 
@@ -530,6 +526,12 @@ if (await RNFS.isResumable(jobId) {
     RNFS.resumeDownload(jobId)
 }
 ```
+
+### (iOS only) `completeHandlerIOS(jobId: number): void`
+
+For use when using background downloads, tell iOS you are done handling a completed download.
+
+Read more about background donwloads in the [Background Downloads Tutorial (iOS)](#background-downloads-tutorial-ios) section.
 
 ### (iOS only) `uploadFiles(options: UploadFileOptions): { jobId: number, promise: Promise<UploadResult> }`
 
@@ -611,7 +613,36 @@ This directory can be used to to share files between application of the same dev
 
 Invalid group identifier will cause a rejection.
 
-For more information read the [Adding an App to an App Group](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW19) section. 
+For more information read the [Adding an App to an App Group](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW19) section.
+
+## Background Downloads Tutorial (iOS)
+
+Background downloads in iOS require a bit of a setup.
+
+First, in your `AppDelegate.m` file add the following:
+
+```
+#import <RNFSManager.h>
+
+...
+
+- (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)())completionHandler
+{
+  [RNFSManager setCompletionHandlerForIdentifier:identifier completionHandler:completionHandler];
+}
+
+```
+
+The `handleEventsForBackgroundURLSession` method is called when a background download is done and your app is not in the foreground.
+
+We need to pass the `completionHandler` to RNFS along with its `identifier`.
+
+The JavaScript will continue to work as usual when the download is done but now you must call `RNFS.completeHandlerIOS(jobId)` when you're done handling the download (show a notification etc.)
+
+**BE AWARE!** iOS will give about 30 sec. to run your code after `handleEventsForBackgroundURLSession` is called and until `completionHandler`
+is triggered so don't do anything that might take a long time (like unzipping), you will be able to do it after the user re-launces the app,
+otherwide iOS will terminate your app.
+
 
 ## Test / Demo app
 

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ type DownloadFileOptions = {
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;
+  resumable?: () => void;
   connectionTimeout?: number // only supported on Android yet
   readTimeout?: number       // only supported on Android yet
 };
@@ -508,10 +509,27 @@ If `progressDivider` = 0, you will receive all `progressCallback` calls, default
                            the fetch interval in `didFinishLaunchingWithOptions`. The `performFetchWithCompletionHandler`
                            callback is handled by RNFS.
 
+If `options.resumable` is provided, it will be invoked when the download has stopped and and can be resumed using `resumeDownload()`.
 
 ### `stopDownload(jobId: number): void`
 
 Abort the current download job with this ID. The partial file will remain on the filesystem.
+
+### `resumeDownload(jobId: number): void`
+
+Resume the current download job with this ID.
+
+### `isResumable(jobId: number): Promise<bool>`
+
+Check if the the download job with this ID is resumable with `resumeDownload()`.
+
+Example:
+
+```
+if (await RNFS.isResumable(jobId) {
+    RNFS.resumeDownload(jobId)
+}
+```
 
 ### (iOS only) `uploadFiles(options: UploadFileOptions): { jobId: number, promise: Promise<UploadResult> }`
 

--- a/RNFSManager.h
+++ b/RNFSManager.h
@@ -9,6 +9,10 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTLog.h>
 
+typedef void (^CompletionHandler)();
+
 @interface RNFSManager : NSObject <RCTBridgeModule>
+
++(void)setCompletionHandlerForIdentifier: (NSString *)identifier completionHandler: (CompletionHandler)completionHandler;
 
 @end

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -508,17 +508,19 @@ RCT_EXPORT_METHOD(isResumable:(nonnull NSNumber *)jobId
     }
 }
 
-RCT_EXPORT_METHOD(completeHandlerIOS:(nonnull NSNumber *)jobId)
+RCT_EXPORT_METHOD(completeHandlerIOS:(nonnull NSNumber *)jobId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
     if (self.uuids) {
         NSString *uuid = [self.uuids objectForKey:[jobId stringValue]];
         CompletionHandler completionHandler = [completionHandlers objectForKey:uuid];
         if (completionHandler) {
-            NSLog(@"Calling completion handler on: %@", uuid);
             completionHandler();
             [completionHandlers removeObjectForKey:uuid];
         }
     }
+    resolve(nil);
 }
 
 RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -454,6 +454,10 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
                                                         @"contentLength": contentLength,
                                                         @"bytesWritten": bytesWritten}];
   };
+    
+    params.resumableCallback = ^() {
+        [self.bridge.eventDispatcher sendAppEventWithName:[NSString stringWithFormat:@"DownloadResumable-%@", jobId] body:nil];
+    };
 
   if (!self.downloaders) self.downloaders = [[NSMutableDictionary alloc] init];
 
@@ -471,6 +475,29 @@ RCT_EXPORT_METHOD(stopDownload:(nonnull NSNumber *)jobId)
   if (downloader != nil) {
     [downloader stopDownload];
   }
+}
+
+RCT_EXPORT_METHOD(resumeDownload:(nonnull NSNumber *)jobId)
+{
+    RNFSDownloader* downloader = [self.downloaders objectForKey:[jobId stringValue]];
+    
+    if (downloader != nil) {
+        [downloader resumeDownload];
+    }
+}
+
+RCT_EXPORT_METHOD(isResumable:(nonnull NSNumber *)jobId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+)
+{
+    RNFSDownloader* downloader = [self.downloaders objectForKey:[jobId stringValue]];
+    
+    if (downloader != nil) {
+        resolve([NSNumber numberWithBool:[downloader isResumable]]);
+    } else {
+        resolve([NSNumber numberWithBool:NO]);
+    }
 }
 
 RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options


### PR DESCRIPTION
Hi,

We've discussed about resumable downloads in my last pull request, I have not made any changes to this feature in this one.

Now about background downloads:
In my app I'm downloading large files, so bg-d/l is crucial.
I've encountered issues with bg-d/l using RNFS and found out it's because the download tasks's completion handler is not being call, thus iOS brutally terminates the app.
So I've added a new method called `completeHandlerIOS(jobId)` that will call that job's completion handler.
Now bg-d/l are safe to use and you can easily do some stuff after the download is done and then call `completeHandlerIOS()`.
readme was updated with a tutorial on how to set this up in the AppDelegate.m file.

I've also removed the bit in the readme about needing to activate 'background fetch' since it's not true, `background fetch` is for periodically connecting to the internet to fetch some data, it's not needed for downloads.