### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ public class MainApplication extends Application implements ReactApplication {
 ```javascript
 // require the module
 var RNFS = require('react-native-fs');
+//Requiring the module with ES6 syntax (import RNFS from 'react-native-fs') throws 'Cannot read property 'readDir' of undefined'
 
 // get a list of files and directories in the main bundle
 RNFS.readDir(RNFS.MainBundlePath) // On Android, use "RNFS.DocumentDirectoryPath" (MainBundlePath is not defined)


### PR DESCRIPTION
Requiring the module with ES6 syntax throws an error.

As this issue is also https://github.com/itinance/react-native-fs/issues/108 about the same error message, I wanted to clarify the readme for future users