### PR TITLE
Expose the iOS `discretionary` flag on `downloadFile`

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -15,6 +15,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 @property (copy) BeginCallback beginCallback;                 // Download has started (headers received)
 @property (copy) ProgressCallback progressCallback;           // Download is progressing
 @property        bool background;                             // Whether to continue download when app is in background
+@property        bool discretionary;                          // Whether the file may be downloaded at the OS's discretion (iOS only)
 @property (copy) NSNumber* progressDivider;
 
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -45,6 +45,7 @@
   if (_params.background) {
     NSString *uuid = [[NSUUID UUID] UUIDString];
     config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:uuid];
+    config.discretionary = _params.discretionary;
   } else {
     config = [NSURLSessionConfiguration defaultSessionConfiguration];
   }

--- a/README.md
+++ b/README.md
@@ -486,7 +486,8 @@ type DownloadFileOptions = {
   fromUrl: string;          // URL to download file from
   toFile: string;           // Local filesystem path to save the file to
   headers?: Headers;        // An object of headers to be passed to the server
-  background?: boolean;
+  background?: boolean;     // Continue the download in the background after the app terminates (iOS only)
+  discretionary?: boolean;  // Allow the OS to control the timing and speed of the download to improve perceived performance  (iOS only)
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -422,6 +422,8 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   params.headers = headers;
   NSNumber* background = options[@"background"];
   params.background = [background boolValue];
+  NSNumber* discretionary = options[@"discretionary"];
+  params.discretionary = [discretionary boolValue];
   NSNumber* progressDivider = options[@"progressDivider"];
   params.progressDivider = progressDivider;
 


### PR DESCRIPTION
This PR exposes the [`discretionary` flag](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc), which is [recommended](https://developer.apple.com/library/content/documentation/Performance/Conceptual/EnergyGuide-iOS/DeferNetworking.html) for use in conjunction with background downloads.