### PR TITLE
Fix multiple callback invocation in iOS with `downloadFile`

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -425,7 +425,14 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   NSNumber* progressDivider = options[@"progressDivider"];
   params.progressDivider = progressDivider;
 
+  __block BOOL callbackFired = NO;
+
   params.completeCallback = ^(NSNumber* statusCode, NSNumber* bytesWritten) {
+    if (callbackFired) {
+      return;
+    }
+    callbackFired = YES;
+
     NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId}];
     if (statusCode) {
       [result setObject:statusCode forKey: @"statusCode"];
@@ -437,6 +444,10 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   };
 
   params.errorCallback = ^(NSError* error) {
+    if (callbackFired) {
+      return;
+    }
+    callbackFired = YES;
     return [self reject:reject withError:error];
   };
 


### PR DESCRIPTION
Given the way error handling happens in the iOS downloader, it's possible for the callbacks to be invoked multiple times, which is illegal. This PR adds a simple block-available variable to track and avoid this scenario.