### PR TITLE
 added a function called getAllExternalFilesDirs to get application-specific directories on all shared/external storage devices

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -201,6 +201,10 @@ var RNFS = {
     return RNFSManager.getFSInfo();
   },
 
+  getAllExternalFilesDirs(): Promise<FSInfoResult> {
+    return RNFSManager.getAllExternalFilesDirs();
+  },
+
   unlink(filepath: string): Promise<void> {
     return RNFSManager.unlink(normalizeFilePath(filepath)).then(() => void 0);
   },

--- a/README.md
+++ b/README.md
@@ -631,6 +631,10 @@ type FSInfoResult = {
 };
 ```
 
+### `getAllExternalFilesDirs(): Promise<ExternalFilesDirs>`
+
+Returns an array with the absolute paths to application-specific directories on all shared/external storage devices where the application can place persistent files it owns. 
+
 ### (iOS only) `pathForGroup(groupIdentifier: string): Promise<string>`
 
 `groupIdentifier` (`string`) Any value from the *com.apple.security.application-groups* entitlements list.

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -672,6 +672,16 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void getAllExternalFilesDirs(Promise promise){
+    File[] allExternalFilesDirs = this.getReactApplicationContext().getExternalFilesDirs(null);
+    WritableArray fs = Arguments.createArray();
+    for (File f : allExternalFilesDirs) {
+      fs.pushString(f.getAbsolutePath());
+    }
+    promise.resolve(fs);
+  }
+
   private void reject(Promise promise, String filepath, Exception ex) {
     if (ex instanceof FileNotFoundException) {
       rejectFileNotFound(promise, filepath);


### PR DESCRIPTION
Replicated [getExternalFilesDirs](https://developer.android.com/reference/android/content/Context.html#getExternalFilesDirs(java.lang.String)) to return array of application-specific directories on all shared/external storage devices where the application can place persistent files it owns. 

This is my first pull request for any project, please let me know, if you want any changes in the PR.