### PR TITLE
Implement requiresMainQueueSetup to remove warning in RN 0.49

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -38,6 +38,11 @@ RCT_EXPORT_MODULE();
   return dispatch_queue_create("pe.lum.rnfs", DISPATCH_QUEUE_SERIAL);
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 RCT_EXPORT_METHOD(readDir:(NSString *)dirPath
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
Here's the warning message removed

[warn][tid:main][RCTModuleData.mm:69] Module RNFSManager requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
