### PR TITLE
Respect readTimeout for downloadFile on iOS

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -17,6 +17,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 @property        bool background;                             // Whether to continue download when app is in background
 @property        bool discretionary;                          // Whether the file may be downloaded at the OS's discretion (iOS only)
 @property (copy) NSNumber* progressDivider;
+@property (copy) NSNumber* readTimeout;
 
 
 @end

--- a/Downloader.m
+++ b/Downloader.m
@@ -51,6 +51,7 @@
   }
 
   config.HTTPAdditionalHeaders = _params.headers;
+  config.timeoutIntervalForRequest = [_params.readTimeout intValue] / 1000.0;
 
   _session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
   _task = [_session downloadTaskWithURL:url];

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ type DownloadFileOptions = {
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;
   connectionTimeout?: number // only supported on Android yet
-  readTimeout?: number       // only supported on Android yet
+  readTimeout?: number       // supported on Android and iOS
 };
 ```
 ```

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -431,6 +431,8 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   params.discretionary = [discretionary boolValue];
   NSNumber* progressDivider = options[@"progressDivider"];
   params.progressDivider = progressDivider;
+  NSNumber* readTimeout = options[@"readTimeout"];
+  params.readTimeout = readTimeout;
 
   __block BOOL callbackFired = NO;
 


### PR DESCRIPTION
`NSURLSessionConfiguration` does not have a concept of `connectionTimeout`, but it does have `timeoutIntervalForRequest` which provides similar functionality to `HttpURLConnection.setReadTimeout()`

Might close(?) issue #208, since this functionality will be as present as it can be on iOS and Android.