### PR TITLE
Fix reference path to ReactNative.csproj

### DIFF
--- a/windows/RNFS/RNFS.csproj
+++ b/windows/RNFS/RNFS.csproj
@@ -134,7 +134,7 @@
     <EmbeddedResource Include="Properties\RNFS.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
+    <ProjectReference Include="..\..\..\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>
     </ProjectReference>


### PR DESCRIPTION
ReactNative project referenced incorrectly. Visual Studio fixes this reference automatically, once you open your project, so this issue doesn't show up. We see this issue when we build our project with MSBuild on staging server.