### PR TITLE
fix: the deployment_target in podspec file dosen't fit the ios project

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license         = pjson["license"]
   s.author          = { "Johannes Lumpe" => "johannes@lum.pe" }
   
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '7.0'
 
   s.source          = { :git => "https://github.com/itinance/react-native-fs", :tag => "v#{s.version}" }
   s.source_files    = '*.{h,m}'


### PR DESCRIPTION
the deployment target of the ios project is 7.0 but I find it is 9.0 in podspec file. It will lead to the error below when someone run `pod install` command with a target edition lower than 9.0 but higher than 7.0 (the edition which is supported by the XCode project)
```
[!] Unable to satisfy the following requirements:

- `RNFS (from `../../rn/node_modules/react-native-fs`)` required by `Podfile`
- `RNFS (from `../../rn/node_modules/react-native-fs`)` required by `Podfile`
- `RNFS (from `../../rn/node_modules/react-native-fs`)` required by `Podfile`

Specs satisfying the `RNFS (from `../../rn/node_modules/react-native-fs`)` dependency were found, but they required a higher minimum deployment target.

```