### PR TITLE
Avoid placing nil value into NSDictionary in downloader

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -463,7 +463,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
                                                  body:@{@"jobId": jobId,
                                                         @"statusCode": statusCode,
                                                         @"contentLength": contentLength,
-                                                        @"headers": headers}];
+                                                        @"headers": headers || [NSNull null]}];
   };
 
   params.progressCallback = ^(NSNumber* contentLength, NSNumber* bytesWritten) {


### PR DESCRIPTION
Simple bug, simple fix.

The [`NSHTTPURLResponse
.allHeaderFields`](https://developer.apple.com/documentation/foundation/nshttpurlresponse/1417930-allheaderfields?language=objc) property can return `nil` if the request experiences a connection error. If we try to place this `nil` value into the `NSDictionary` literal, we get an exception and a crash.

The fix is simply to insert the `NSNull` singleton instead, which will surface the `null` value to the JavaScript.