### PR TITLE
fixed: warning: this block declaration is not a prototype [-Wstrict-prototypes]

### DIFF
--- a/Uploader.h
+++ b/Uploader.h
@@ -3,7 +3,7 @@
 
 typedef void (^UploadCompleteCallback)(NSString*, NSURLResponse *);
 typedef void (^UploadErrorCallback)(NSError*);
-typedef void (^UploadBeginCallback)();
+typedef void (^UploadBeginCallback)(void);
 typedef void (^UploadProgressCallback)(NSNumber*, NSNumber*);
 
 @interface RNFSUploadParams : NSObject


### PR DESCRIPTION
Fixes the following issue/error:

```
In file included from node_modules/react-native-fs/Uploader.m:1:
node_modules/react-native-fs/Uploader.h:6:36: warning: this block declaration is not a prototype [-Wstrict-prototypes]
typedef void (^UploadBeginCallback)();
                                   ^
                                    void
```