### PR TITLE
Add UWP tests to NPM ignore

### DIFF
--- a/windows/.npmignore
+++ b/windows/.npmignore
@@ -7,3 +7,6 @@ x86/
 bin/
 obj/
 .vs/
+
+# Don't publish tests to NPM
+RNFS.Tests/


### PR DESCRIPTION
The `react-native link` command will unintentionally link the `RNFS.Tests` project instead of the `RNFS` project. This adds `RNFS.Tests` to `.npmignore` so this is no longer a problem.