### PR TITLE
Remove create-react-class from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-native": "^0.51.0",
-    "prop-types": "15.6.0",
-    "create-react-class": "^15.6.2"
+    "prop-types": "15.6.0"
   }
 }


### PR DESCRIPTION
`create-react-class` is only used in tests and is already specified as a `devDependency`, therefore the `peerDependency` is redundant and causes an avoidable warning.

Partially solves #439