### PR TITLE
Wrong return type in getAllExternalFilesDirs signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ type FSInfoResult = {
 };
 ```
 
-### `getAllExternalFilesDirs(): Promise<string>`
+### `getAllExternalFilesDirs(): Promise<string[]>`
 
 Returns an array with the absolute paths to application-specific directories on all shared/external storage devices where the application can place persistent files it owns. 
 


### PR DESCRIPTION
Instead of string, it should be array of strings