### PR TITLE
Adding a new version of getFsInfo method 

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -203,6 +203,10 @@ var RNFS = {
     return RNFSManager.getFSInfo();
   },
 
+  getFSInfoPath(filepath: string): Promise<FSInfoResult> {
+    return RNFSManager.getFSInfoPath(filepath);
+  },
+
   getAllExternalFilesDirs(): Promise<string> {
     return RNFSManager.getAllExternalFilesDirs();
   },

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -677,8 +677,19 @@ public class RNFSManager extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getFSInfo(Promise promise) {
-    File path = Environment.getDataDirectory();
-    StatFs stat = new StatFs(path.getPath());
+    File file = Environment.getDataDirectory();
+    getFSInfoForFile(file, promise);
+  }
+
+  @ReactMethod
+  public void getFSInfoPath(String path, Promise promise) {
+    File file = new File(path);
+    getFSInfoForFile(file, promise);
+  }
+
+  private void getFSInfoForFile(File file, Promise promise) {
+    String path = file.getPath();
+    StatFs stat = new StatFs(path);
     long totalSpace;
     long freeSpace;
     if (android.os.Build.VERSION.SDK_INT >= 18) {


### PR DESCRIPTION
With this new method, it's possible to get information about any mounted volume (just pass a file from the desired volume). It's useful in Android in order to get info about an external volume (e.g. sdcard)