### PR TITLE
Add urldecode when check if the file exists

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -178,7 +178,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   @ReactMethod
   public void exists(String filepath, Promise promise) {
     try {
-      File file = new File(filepath);
+      File file = new File(URLDecoder.decode(filepath, "UTF-8"));
       promise.resolve(file.exists());
     } catch (Exception ex) {
       ex.printStackTrace();


### PR DESCRIPTION
As #464 mentioned,  If the file save with a name like `files/persist/persist%3AUser`, the file will be actually saved as `files/persist/persist:User` on phone storage. So this should be do the same to the `exists` method.

I haven't test much on this patch(only test with `redux-persist-fs-storage`, it works), hope it will work on all conditions.