### PR TITLE
Align RNFS.read() behaviour on Android OS.

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -206,9 +206,9 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       InputStream inputStream = getInputStream(filepath);
       byte[] buffer = new byte[length];
       inputStream.skip(position);
-      inputStream.read(buffer, 0, length);
+      int bytesRead = inputStream.read(buffer, 0, length);
 
-      String base64Content = Base64.encodeToString(buffer, Base64.NO_WRAP);
+      String base64Content = Base64.encodeToString(buffer, 0, bytesRead, Base64.NO_WRAP);
 
       promise.resolve(base64Content);
     } catch (Exception ex) {


### PR DESCRIPTION
Hello,

I have found out the hard way that `RNFS.read(filePath, length, position, options)` behaves differently across OSes.

Currently there is no easy way to find out if the partial read has reached the EOF.

`iOS` when reading the last part of the file returns a `string` shorter than requested.

On `Android` check for returned string length always results in the same length that was requested. To find out how much data was actually read one must look for null characters.

This is an inconsistency that should be fixed.

### Example
```
// Prepare file
await RNFS.writeFile(filePath, 'Test1', 'utf8');

// Read file
const result0 = await RNFS.read(filePath, 3, 0, 'utf8');
const result1 = await RNFS.read(filePath, 3, 3, 'utf8');
const result2 = await RNFS.read(filePath, 3, 6, 'utf8');
const result3 = await RNFS.read(filePath, 3, 4, 'utf8');

// Check results
console.log(`RNFS.read(filePath, 3, 0, 'utf8') => result: '${result0}' result.length: ${result0.length} charValues: ${charValues(result0)}`);
console.log(`RNFS.read(filePath, 3, 3, 'utf8') => result: '${result1}' result.length: ${result1.length} charValues: ${charValues(result1)}`);
console.log(`RNFS.read(filePath, 3, 6, 'utf8') => result: '${result2}' result.length: ${result2.length} charValues: ${charValues(result2)}`);
console.log(`RNFS.read(filePath, 3, 4, 'utf8') => result: '${result3}' result.length: ${result3.length} charValues: ${charValues(result3)}`);
```

Where `charValues` is:
```
const charValues = (aString) => {
  let returnString = '[';
  for (let i = 0; i < aString.length; i += 1) {
    if (returnString.length > 1) returnString += ', ';
    returnString += aString.charCodeAt(i);
  }
  returnString += ']';
  return returnString;
};
```

### iOS results:
```
RNFS.read(filePath, 3, 0, 'utf8') => result: 'Tes' result.length: 3 charValues: [84, 101, 115]
RNFS.read(filePath, 3, 3, 'utf8') => result: 't1' result.length: 2 charValues: [116, 49]
RNFS.read(filePath, 3, 6, 'utf8') => result: '' result.length: 0 charValues: []
RNFS.read(filePath, 3, 4, 'utf8') => result: '1' result.length: 1 charValues: [49]
```

### Android results:
```
RNFS.read(filePath, 3, 0, 'utf8') => result: 'Tes' result.length: 3 charValues: [84, 101, 115]
RNFS.read(filePath, 3, 3, 'utf8') => result: 't1' result.length: 3 charValues: [116, 49, 0]
RNFS.read(filePath, 3, 6, 'utf8') => result: '' result.length: 3 charValues: [0, 0, 0]
RNFS.read(filePath, 3, 4, 'utf8') => result: '1' result.length: 3 charValues: [49, 0, 0]
```

### Android results with changes from this PR:
With the change contained in this pull request the Android results are aligned to iOS and look like this:
```
RNFS.read(filePath, 3, 0, 'utf8') => result: 'Tes' result.length: 3 charValues: [84, 101, 115]
RNFS.read(filePath, 3, 3, 'utf8') => result: 't1' result.length: 2 charValues: [116, 49]
RNFS.read(filePath, 3, 6, 'utf8') => result: '' result.length: 0 charValues: []
RNFS.read(filePath, 3, 4, 'utf8') => result: '1' result.length: 1 charValues: [49]
```

Best Regards