### PR TITLE
Android: Resolve filepath for content URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ DerivedData
 # Pods - for those of you who use CocoaPods
 Pods
 update-test.sh
+.vscode/
+android/.gradle/*
+android/gradle/*
+android/*.iml
+android/local.properties

--- a/FS.common.js
+++ b/FS.common.js
@@ -25,7 +25,7 @@ var getJobId = () => {
   return jobId;
 };
 
-var normalizeFilePath = (path: string) => (path.startsWith('file://') && !path.startsWith('content://') ? path.slice(7) : path);
+var normalizeFilePath = (path: string) => (path.startsWith('file://') ? path.slice(7) : path);
 
 type MkdirOptions = {
   NSURLIsExcludedFromBackupKey?: boolean; // iOS only
@@ -42,13 +42,13 @@ type ReadDirItem = {
 };
 
 type StatResult = {
-  name: ?string;     // The name of the item
+  name: ?string;     // The name of the item TODO: why is this not documented?
   path: string;     // The absolute path to the item
   size: string;     // Size in bytes
   mode: number;     // UNIX file mode
   ctime: number;    // Created date
   mtime: number;    // Last modified date
-  originalFilepath: ?string;    // In case of content uri this is the pointed file path, otherwise is the same as path
+  originalFilepath: string;    // In case of content uri this is the pointed file path, otherwise is the same as path
   isFile: () => boolean;        // Is the file just a file?
   isDirectory: () => boolean;   // Is the file a directory?
 };

--- a/FS.common.js
+++ b/FS.common.js
@@ -25,7 +25,7 @@ var getJobId = () => {
   return jobId;
 };
 
-var normalizeFilePath = (path: string) => (path.startsWith('file://') ? path.slice(7) : path);
+var normalizeFilePath = (path: string) => (path.startsWith('file://') && !path.startsWith('content://') ? path.slice(7) : path);
 
 type MkdirOptions = {
   NSURLIsExcludedFromBackupKey?: boolean; // iOS only
@@ -42,12 +42,13 @@ type ReadDirItem = {
 };
 
 type StatResult = {
-  name: string;     // The name of the item
+  name: ?string;     // The name of the item
   path: string;     // The absolute path to the item
   size: string;     // Size in bytes
   mode: number;     // UNIX file mode
   ctime: number;    // Created date
   mtime: number;    // Last modified date
+  originalFilepath: ?string;    // In case of content uri this is the pointed file path, otherwise is the same as path
   isFile: () => boolean;        // Is the file just a file?
   isDirectory: () => boolean;   // Is the file a directory?
 };
@@ -272,10 +273,12 @@ var RNFS = {
   stat(filepath: string): Promise<StatResult> {
     return RNFSManager.stat(normalizeFilePath(filepath)).then((result) => {
       return {
+        'path': filepath,
         'ctime': new Date(result.ctime * 1000),
         'mtime': new Date(result.mtime * 1000),
         'size': result.size,
         'mode': result.mode,
+        'originalFilepath': result.originalFilepath,
         isFile: () => result.type === RNFSFileTypeRegular,
         isDirectory: () => result.type === RNFSFileTypeDirectory,
       };

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Node.js style version of `readDir` that returns only the names. Note the lowerca
 
 ### `stat(filepath: string): Promise<StatResult>`
 
-Stats an item at `path`.
+Stats an item at `filepath`. If the `filepath` is linked to a virtual file, for example Android Content URI, the `originalPath` can be used to find the pointed file path. 
 The promise resolves with an object with the following properties:
 
 ```

--- a/README.md
+++ b/README.md
@@ -383,10 +383,12 @@ The promise resolves with an object with the following properties:
 
 ```
 type StatResult = {
+  path:            // The same as filepath argument
   ctime: date;     // The creation date of the file
   mtime: date;     // The last modified date of the file
   size: string;     // Size in bytes
   mode: number;     // UNIX file mode
+  originalFilepath: string;    // ANDROID: In case of content uri this is the pointed file path, otherwise is the same as path
   isFile: () => boolean;        // Is the file just a file?
   isDirectory: () => boolean;   // Is the file a directory?
 };


### PR DESCRIPTION
File sharing with the content URI will not use the original filename, I've just updated the `stat` API to return the original file path (the file pointed by the content uri).

Example:
<img width="648" alt="screen shot 2018-04-19 at 19 09 27" src="https://user-images.githubusercontent.com/2692166/39008180-3f5178e8-4408-11e8-8d3b-7f380589b68a.png">


