### PR TITLE
Add ExternalCachesDirectoryPath

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -557,6 +557,7 @@ var RNFS = {
 
   MainBundlePath: RNFSManager.RNFSMainBundlePath,
   CachesDirectoryPath: RNFSManager.RNFSCachesDirectoryPath,
+  ExternalCachesDirectoryPath: RNFSManager.RNFSExternalCachesDirectoryPath,
   DocumentDirectoryPath: RNFSManager.RNFSDocumentDirectoryPath,
   ExternalDirectoryPath: RNFSManager.RNFSExternalDirectoryPath,
   ExternalStorageDirectoryPath: RNFSManager.RNFSExternalStorageDirectoryPath,

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ RNFS.readDir(RNFS.MainBundlePath) // On Android, use "RNFS.DocumentDirectoryPath
 var RNFS = require('react-native-fs');
 
 // create a path you want to write to
-// :warning: on iOS, you cannot write into `RNFS.MainBundlePath`, 
+// :warning: on iOS, you cannot write into `RNFS.MainBundlePath`,
 // but `RNFS.DocumentDirectoryPath` exists on both platforms and is writable
 var path = RNFS.DocumentDirectoryPath + '/test.txt';
 
@@ -327,6 +327,7 @@ The following constants are available on the `RNFS` export:
 
 - `MainBundlePath` (`String`) The absolute path to the main bundle directory (not available on Android)
 - `CachesDirectoryPath` (`String`) The absolute path to the caches directory
+- `ExternalCachesDirectoryPath` (`String`) The absolute path to the external caches directory (android only)
 - `DocumentDirectoryPath`  (`String`) The absolute path to the document directory
 - `TemporaryDirectoryPath` (`String`) The absolute path to the temporary directory (falls back to Caching-Directory on Android)
 - `LibraryDirectoryPath` (`String`) The absolute path to the NSLibraryDirectory (iOS only)
@@ -656,7 +657,7 @@ type FSInfoResult = {
 
 ### (Android only) `getAllExternalFilesDirs(): Promise<string[]>`
 
-Returns an array with the absolute paths to application-specific directories on all shared/external storage devices where the application can place persistent files it owns. 
+Returns an array with the absolute paths to application-specific directories on all shared/external storage devices where the application can place persistent files it owns.
 
 ### (iOS only) `pathForGroup(groupIdentifier: string): Promise<string>`
 

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -41,6 +41,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   private static final String RNFSPicturesDirectoryPath = "RNFSPicturesDirectoryPath";
   private static final String RNFSTemporaryDirectoryPath = "RNFSTemporaryDirectoryPath";
   private static final String RNFSCachesDirectoryPath = "RNFSCachesDirectoryPath";
+  private static final String RNFSExternalCachesDirectoryPath = "RNFSExternalCachesDirectoryPath";
   private static final String RNFSDocumentDirectory = "RNFSDocumentDirectory";
 
   private static final String RNFSFileTypeRegular = "RNFSFileTypeRegular";
@@ -762,6 +763,13 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       constants.put(RNFSExternalDirectoryPath, externalDirectory.getAbsolutePath());
     } else {
       constants.put(RNFSExternalDirectoryPath, null);
+    }
+
+    File externalCachesDirectory = this.getReactApplicationContext().getExternalCacheDir();
+    if (externalCachesDirectory != null) {
+      constants.put(RNFSExternalCachesDirectoryPath, externalCachesDirectory.getAbsolutePath());
+    } else {
+      constants.put(RNFSExternalCachesDirectoryPath, null);
     }
 
     return constants;


### PR DESCRIPTION
`ExternalCachesDirectoryPath` is useful if you want to store temp files that you want to share with other apps. `CachesDirectoryPath` doesn't allow this.