### PR TITLE
Decrease specificity of react peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "create-react-class": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.2.0",
+    "react": "^16.0.0",
     "react-native": "^0.51.0",
     "prop-types": "15.6.0"
   }


### PR DESCRIPTION
Node 6, NPM 6, react-native@~0.51.0, react-native-fs@2.9.12

With react@~16.0.0 installed
`npm WARN react-native-fs@2.9.12 requires a peer of react@^16.2.0 but none is installed. You must install peer dependencies yourself.`

With react@~16.2.0 installed
`npm WARN react-native@0.51.1 requires a peer of react@16.0.0 but none is installed. You must install peer dependencies yourself.`

Disclaimer: I'm working this problem in a release engineering capacity; I have no working knowledge of react. It seems semver-reasonable to me to decrement the minor version.