### PR TITLE
fix(upload): prevent memory leaks from retained jobs

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -559,6 +559,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
   params.method = method;
 
   params.completeCallback = ^(NSString* body, NSURLResponse *resp) {
+    [self.uploaders removeObjectForKey:[jobId stringValue]];
 
     NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId,
                                                                                      @"body": body}];
@@ -570,6 +571,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
   };
 
   params.errorCallback = ^(NSError* error) {
+    [self.uploaders removeObjectForKey:[jobId stringValue]];
     return [self reject:reject withError:error];
   };
 


### PR DESCRIPTION
Ran into the same issue as #499 particularly since our application uploads a number of files and is rarely re-launched. This PR simply removes the job from the `NSMutableDictionary` as soon as it either succeeds or fails.