### PR TITLE
make sure to return the original file uri if content:// scheme is not used

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -81,7 +81,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
 
   private String getOriginalFilepath(String filepath) throws IORejectionException {
     Uri uri = getFileUri(filepath);
-    String originalFilepath = "";
+    String originalFilepath = filepath;
     if (uri.getScheme().equals("content")) {
       try {
         Cursor cursor = reactContext.getContentResolver().query(uri, null, null, null, null);


### PR DESCRIPTION
If the stat function was called on Android using a path like file://... the getOriginalFilePath function would just return an empty string which resulted in a 'File does not exist exception'.
So if the original path is given as a file:// scheme just leave it be.