### PR TITLE
Fixes an `IndexOutOfBounds` while uploading files in Android

### DIFF
--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -102,21 +102,21 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                         "Content-Disposition: form-data; name=\"" + name + "\";filename=\"" + filename + "\"" + crlf);
                 request.writeBytes("Content-Type: " + filetype + crlf);
                 request.writeBytes(crlf);
-                byte[] b = new byte[(int) file.length()];
 
                 FileInputStream fileInputStream = new FileInputStream(file);
 
                 Readed = 0;
                 bufferAvailable = 4096;
                 bufferSize = Math.min(bufferAvailable, maxBufferSize);
-                byteRead = fileInputStream.read(b, 0, bufferSize);
-                totalSize = b.length;
+                byte[] b = new byte[bufferSize];
+                totalSize = (int)file.length();
+                byteRead = fileInputStream.read(b, 0, Math.min(totalSize - Readed, bufferSize));
                 Readed += byteRead;
                 while (byteRead > 0) {
                     if (mAbort.get())
                         throw new Exception("Upload has been aborted");
-                    request.write(b, 0, bufferSize);
-                    byteRead = fileInputStream.read(b, 0, bufferSize);
+                    request.write(b, 0, Math.min(totalSize, bufferSize));
+                    byteRead = fileInputStream.read(b, 0, Math.min(totalSize - Readed, bufferSize));
                     if (byteRead == -1) {
                         mParams.onUploadProgress.onUploadProgress(fileCount, totalSize, Readed);
                     } else {
@@ -150,6 +150,8 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
             res.headers = responseHeaders;
             res.body = response;
             res.statusCode = statusCode;
+        } catch(Exception ex) {
+            System.out.println(ex.getMessage());
         } finally {
             if (connection != null)
                 connection.disconnect();

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -115,7 +115,7 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 while (byteRead > 0) {
                     if (mAbort.get())
                         throw new Exception("Upload has been aborted");
-                    request.write(b, 0, Math.min(totalSize, bufferSize));
+                    request.write(b, 0, byteRead);
                     byteRead = fileInputStream.read(b, 0, Math.min(totalSize - Readed, bufferSize));
                     if (byteRead == -1) {
                         mParams.onUploadProgress.onUploadProgress(fileCount, totalSize, Readed);
@@ -150,7 +150,7 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
             res.headers = responseHeaders;
             res.body = response;
             res.statusCode = statusCode;
-        }  finally {
+        } finally {
             if (connection != null)
                 connection.disconnect();
             if (request != null)

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -150,9 +150,7 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
             res.headers = responseHeaders;
             res.body = response;
             res.statusCode = statusCode;
-        } catch(Exception ex) {
-            System.out.println(ex.getMessage());
-        } finally {
+        }  finally {
             if (connection != null)
                 connection.disconnect();
             if (request != null)


### PR DESCRIPTION
# Overview
Fixes https://github.com/itinance/react-native-fs/issues/509.

# Description
According to the documentation of FileInputStream, an IndexOutOfBoundsException is thrown in the following cases:
  1. off is negative
  2. len is negative
  3. len is greater than `b.length - off`

The third case was the one that was throwing an exception when reading from the `FileInputStream`. More information in the [issue](https://github.com/itinance/react-native-fs/issues/509)