### PR TITLE
Add `cacheable` option to `downloadFile` on iOS

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -18,6 +18,7 @@ typedef void (^ResumableCallback)();
 @property (copy) ResumableCallback resumableCallback;         // Download has stopped but is resumable
 @property        bool background;                             // Whether to continue download when app is in background
 @property        bool discretionary;                          // Whether the file may be downloaded at the OS's discretion (iOS only)
+@property        bool cacheable;                              // Whether the file may be stored in the shared NSURLCache (iOS only)
 @property (copy) NSNumber* progressDivider;
 @property (copy) NSNumber* readTimeout;
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -55,6 +55,10 @@
     config = [NSURLSessionConfiguration defaultSessionConfiguration];
   }
 
+  if (!_params.cacheable) {
+    config.URLCache = nil;
+  }
+
   config.HTTPAdditionalHeaders = _params.headers;
   config.timeoutIntervalForRequest = [_params.readTimeout intValue] / 1000.0;
 

--- a/FS.common.js
+++ b/FS.common.js
@@ -62,6 +62,7 @@ type DownloadFileOptions = {
   headers?: Headers;        // An object of headers to be passed to the server
   background?: boolean;     // Continue the download in the background after the app terminates (iOS only)
   discretionary?: boolean;  // Allow the OS to control the timing and speed of the download to improve perceived performance  (iOS only)
+  cacheable?: boolean;      // Whether the download can be stored in the shared NSURLCache (iOS only)
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ type DownloadFileOptions = {
   headers?: Headers;        // An object of headers to be passed to the server
   background?: boolean;     // Continue the download in the background after the app terminates (iOS only)
   discretionary?: boolean;  // Allow the OS to control the timing and speed of the download to improve perceived performance  (iOS only)
+  cacheable?: boolean;      // Whether the download can be stored in the shared NSURLCache (iOS only, defaults to true)
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -432,6 +432,8 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   params.background = [background boolValue];
   NSNumber* discretionary = options[@"discretionary"];
   params.discretionary = [discretionary boolValue];
+  NSNumber* cacheable = options[@"cacheable"];
+  params.cacheable = cacheable ? [cacheable boolValue] : YES;
   NSNumber* progressDivider = options[@"progressDivider"];
   params.progressDivider = progressDivider;
   NSNumber* readTimeout = options[@"readTimeout"];


### PR DESCRIPTION
By supplying `cacheable: false` as an option to `downloadFile()`, you can prevent it from being stored in the process's shared `NSURLCache`.

This is valuable behavior for two reasons:

1. The shared `NSURLCache` is somewhat small by default, so it helps to have control over whether to populate it.

2. Downloaded files tend to be accessed from the file-system after begin downloaded, which means it's just a waste of space to cache their contents as well.

The default value (`true`) was chosen to make this a non-breaking change.