### PR TITLE
Slightly improve redirect handling

### DIFF
--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -67,13 +67,10 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
       int lengthOfFile = connection.getContentLength();
 
       boolean isRedirect = (
-        statusCode != HttpURLConnection.HTTP_OK &&
-        (
-          statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
-          statusCode == HttpURLConnection.HTTP_MOVED_TEMP ||
-          statusCode == 307 ||
-          statusCode == 308
-        )
+        statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
+        statusCode == HttpURLConnection.HTTP_MOVED_TEMP ||
+        statusCode == 307 ||
+        statusCode == 308
       );
 
       if (isRedirect) {
@@ -81,7 +78,16 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         connection.disconnect();
 
         connection = (HttpURLConnection) new URL(redirectURL).openConnection();
-        connection.setConnectTimeout(5000);
+        
+        ReadableMapKeySetIterator iterator = param.headers.keySetIterator();
+
+        while (iterator.hasNextKey()) {
+          String key = iterator.nextKey();
+          String value = param.headers.getString(key);
+          connection.setRequestProperty(key, value);
+        }
+        
+        connection.setConnectTimeout(param.readTimeout);
         connection.connect();
 
         statusCode = connection.getResponseCode();


### PR DESCRIPTION
- Remove unneeded check for HTTP_OK (if any of the other values is true it can't be 200)
- Reset connect timeout after redirect
- Reset connection options after redirect

There are a few open items:
- instead of copy and pasting the connection code this should either be
  extracted in its own function or be made a loop to even follow multiple
  redirects (mind endless redirects)
- the meaning of timeout should be clear (if this returns shortly before
  running in a timeout with a redirect total time till timeout is the doubled
  timeout)
- it should be verified that resetting all options won't leak sensitive data
  (i.e. on redirect to a different host)
- There should be constants/enum for all HTTP Status codes checked (or for none)
- The check for response code might be written as switch (subjective choice
  based on taste) instead of a long logical clause
- This whole patch isn't tested at all