### PR TITLE
Add missing callbacks in UploadFileOptions  flow type

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -102,7 +102,9 @@ type UploadFileOptions = {
   fields?: Fields;          // An object of fields to be passed to the server
   method?: string;          // Default is 'POST', supports 'POST' and 'PUT'
   begin?: (res: UploadBeginCallbackResult) => void;
+  beginCallback?: (res: UploadBeginCallbackResult) => void;
   progress?: (res: UploadProgressCallbackResult) => void;
+  progressCallback?: (res: UploadProgressCallbackResult) => void,
 };
 
 type UploadFileItem = {


### PR DESCRIPTION
The flow version (`0.75.0`) shipped with the latest `react-native` version (`0.56.0`) will fail when using `react-native-fs`:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-fs/FS.common.js:517:9

Property beginCallback is missing in UploadFileOptions [1].

 [1] 496│   uploadFiles(options: UploadFileOptions): { jobId: number, promise: Promise<UploadResult> } {
        :
     514│     if (options.begin) {
     515│       subscriptions.push(NativeAppEventEmitter.addListener('UploadBegin-' + jobId, options.begin));
     516│     }
     517│     if (options.beginCallback && options.beginCallback instanceof Function) {
```

The two deprecated callbacks should to be added to the flow type.