### PR TITLE
copyFile: fix missing parameter on Android.

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -334,7 +334,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void copyFile(String filepath, String destPath, Promise promise) {
+  public void copyFile(String filepath, String destPath, ReadableMap options, Promise promise) {
     try {
       copyFile(filepath, destPath);
 


### PR DESCRIPTION
Currently, my Android app crashes when I invoke copyFile, because the `options` parameter is missing.

JS:
```js
copyFile(filepath: string, destPath: string, options: FileOptions = {}): Promise<void>
```

iOS:
```objc
RCT_EXPORT_METHOD(copyFile:(NSString *)filepath
                  destPath:(NSString *)destPath
                  options:(NSDictionary *)options
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
```

but Android:
```java
public void copyFile(String filepath, String destPath, Promise promise)
```