### PR TITLE
Fix issue #566 android progress callback not sync and handle uppercase file extension mimetype

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -734,11 +734,10 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       };
 
       params.onUploadProgress = new UploadParams.onUploadProgress() {
-        public void onUploadProgress(int fileCount,int totalBytesExpectedToSend,int totalBytesSent) {
+        public void onUploadProgress(int totalBytesExpectedToSend,int totalBytesSent) {
           WritableMap data = Arguments.createMap();
 
           data.putInt("jobId", jobId);
-          data.putInt("FileID",fileCount);
           data.putInt("totalBytesExpectedToSend", totalBytesExpectedToSend);
           data.putInt("totalBytesSent", totalBytesSent);
 

--- a/android/src/main/java/com/rnfs/UploadParams.java
+++ b/android/src/main/java/com/rnfs/UploadParams.java
@@ -10,7 +10,7 @@ public class UploadParams {
         void onUploadComplete(UploadResult res);
     }
     public interface onUploadProgress{
-        void onUploadProgress(int fileCount,int totalBytesExpectedToSend,int totalBytesSent);
+        void onUploadProgress(int totalBytesExpectedToSend,int totalBytesSent);
     }
     public interface onUploadBegin{
         void onUploadBegin();

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -93,7 +93,7 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 File file = new File(map.getString("filepath"));
                 String fileHeaderType = twoHyphens + boundary + crlf +
                         "Content-Disposition: form-data; name=\"" + name + "\"; filename=\"" + filename + "\"" + crlf +
-                        "Content-Type: " + filetype + crlf +"Content-Transfer-Encoding: binary" + crlf;
+                        "Content-Type: " + filetype + crlf;
                 long fileLength = file.length();
                 totalFileLength += fileLength ;
                 if(params.files.toArray().length - 1 == fileCount){

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -100,9 +100,9 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                         "Content-Type: " + filetype + crlf + crlf;
                 long fileLength = file.length() + tail.length();
                 totalFileLength += fileLength;
-                String fileLengthHeader = "Content-length: " + fileLength + crlf;
-                fileHeader[fileCount] = fileHeaderType + fileLengthHeader + crlf;
-                stringData += fileHeaderType + fileLengthHeader + crlf;
+//                String fileLengthHeader = "Content-length: " + fileLength + crlf;
+                fileHeader[fileCount] = fileHeaderType;
+                stringData += fileHeaderType;
                 fileCount++;
             }
             fileCount = 0;
@@ -116,13 +116,12 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
             request.writeBytes(metaData);
             for (ReadableMap map : params.files) {
                 request.writeBytes(fileHeader[fileCount]);
-                request.flush();
                 File file = new File(map.getString("filepath"));
                 FileInputStream fis = new FileInputStream(file);
                 int fileLength = (int) file.length();
                 int bytes_read = 0;
                 int bytesReadTotal = 0;
-                int buffer_size = fileLength / 500;
+                int buffer_size = fileLength / 100;
                 byte[] buffer = new byte[buffer_size];
                 while ((bytes_read = fis.read(buffer, 0, Math.min(fileLength - bytesReadTotal, buffer_size))) > 0) {
                     request.write(buffer, 0, bytes_read);

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -97,12 +97,12 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 File file = new File(map.getString("filepath"));
                 String fileHeaderType = twoHyphens + boundary + crlf +
                         "Content-Disposition: form-data; name=\"" + name + "\";filename=\"" + filename + "\"" + crlf +
-                        "Content-Type: " + filetype + crlf + crlf;
+                        "Content-Type: " + filetype + crlf ;
                 long fileLength = file.length() + tail.length();
                 totalFileLength += fileLength;
-//                String fileLengthHeader = "Content-length: " + fileLength + crlf;
-                fileHeader[fileCount] = fileHeaderType;
-                stringData += fileHeaderType;
+                String fileLengthHeader = "Content-length: " + fileLength + crlf;
+                fileHeader[fileCount] = fileHeaderType + fileLengthHeader + crlf;
+                stringData += fileHeaderType + fileLengthHeader + crlf;
                 fileCount++;
             }
             fileCount = 0;

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -54,7 +54,7 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
         String tail = crlf + twoHyphens + boundary + twoHyphens + crlf;
         String metaData = "", stringData = "";
         String[] fileHeader;
-        int bufferSize, totalSize, byteRead, statusCode, bufferAvailable, progress,contentLength,byteSentTotal;
+        int statusCode, byteSentTotal;
         int fileCount = 0;
         long totalFileLength = 0;
         BufferedInputStream responseStream = null;
@@ -120,13 +120,11 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 File file = new File(map.getString("filepath"));
                 int fileLength = (int) file.length();
                 int bytes_read = 0;
-                int bytesReadTotal = 0;
                 int buffer_size =(int) Math.ceil(fileLength / 100.f);
                 BufferedInputStream bufInput = new BufferedInputStream(new FileInputStream(file));
                 byte[] buffer = new byte[buffer_size];
                 while ((bytes_read = bufInput.read(buffer)) != -1) {
                     request.write(buffer, 0, bytes_read);
-                    bytesReadTotal += bytes_read;
                     byteSentTotal += bytes_read;
                     mParams.onUploadProgress.onUploadProgress((int) totalFileLength - tail.length(), byteSentTotal);
                 }

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -170,7 +170,10 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
         String type = null;
         String extension = MimeTypeMap.getFileExtensionFromUrl(path);
         if (extension != null) {
-            type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+            type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.toLowerCase());
+        }
+        if (type == null) {
+            type = "*/*";
         }
         return type;
     }


### PR DESCRIPTION
### Problem
1. This is an issue because the progress is not synced with what's really sent to the server. Bytes sent are wrong.
2. If the file extension is uppercase mimetype will return null.
### Reason
1. Two situations might cause this issue:

  - 1. HttpURLConnection.setFixedLengthStreamingMode should be called,and it's parameter should 
     be request body length.
  - 2. It might be react-native bugs. When I was sending too much event to sendEvent, it will have 
     some delay.
2. Android package MimeUtils cannot get mimetype when the file extension is uppercase.
### Resolve
1.
   - 1. Call setFixedLengthStreamingMode and calculate correct content-length.
   - 2. Send less event to sendEvent.
2. Add lowerCase to file extension when getMimeType
