### PR TITLE
fix Android downloadFile overflow contentLength and bytesWritten

### DIFF
--- a/android/src/main/java/com/rnfs/DownloadParams.java
+++ b/android/src/main/java/com/rnfs/DownloadParams.java
@@ -12,11 +12,11 @@ public class DownloadParams {
   }
 
   public interface OnDownloadBegin {
-    void onDownloadBegin(int statusCode, int contentLength, Map<String, String> headers);
+    void onDownloadBegin(int statusCode, long contentLength, Map<String, String> headers);
   }
 
   public interface OnDownloadProgress {
-    void onDownloadProgress(int contentLength, int bytesWritten);
+    void onDownloadProgress(long contentLength, long bytesWritten);
   }
 
   public URL src;

--- a/android/src/main/java/com/rnfs/DownloadResult.java
+++ b/android/src/main/java/com/rnfs/DownloadResult.java
@@ -2,6 +2,6 @@ package com.rnfs;
 
 public class DownloadResult {
   public int statusCode;
-  public int bytesWritten;
+  public long bytesWritten;
   public Exception exception;
 }

--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -19,7 +19,7 @@ import android.os.AsyncTask;
 
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 
-public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult> {
+public class Downloader extends AsyncTask<DownloadParams, long[], DownloadResult> {
   private DownloadParams mParam;
   private AtomicBoolean mAbort = new AtomicBoolean(false);
   DownloadResult res;
@@ -64,7 +64,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
       connection.connect();
 
       int statusCode = connection.getResponseCode();
-      int lengthOfFile = connection.getContentLength();
+      long lengthOfFile = connection.getContentLengthLong();
 
       boolean isRedirect = (
         statusCode != HttpURLConnection.HTTP_OK &&
@@ -85,7 +85,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         connection.connect();
 
         statusCode = connection.getResponseCode();
-        lengthOfFile = connection.getContentLength();
+        lengthOfFile = connection.getContentLengthLong();
       }
       if(statusCode >= 200 && statusCode < 300) {
         Map<String, List<String>> headers = connection.getHeaderFields();
@@ -107,7 +107,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         output = new FileOutputStream(param.dest);
 
         byte data[] = new byte[8 * 1024];
-        int total = 0;
+        long total = 0;
         int count;
         double lastProgressValue = 0;
 
@@ -116,14 +116,14 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
 
           total += count;
           if (param.progressDivider <= 0) {
-            publishProgress(new int[]{lengthOfFile, total});
+            publishProgress(new long[]{lengthOfFile, total});
           } else {
             double progress = Math.round(((double) total * 100) / lengthOfFile);
             if (progress % param.progressDivider == 0) {
               if ((progress != lastProgressValue) || (total == lengthOfFile)) {
                 Log.d("Downloader", "EMIT: " + String.valueOf(progress) + ", TOTAL:" + String.valueOf(total));
                 lastProgressValue = progress;
-                publishProgress(new int[]{lengthOfFile, total});
+                publishProgress(new long[]{lengthOfFile, total});
               }
             }
           }
@@ -146,7 +146,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
   }
 
   @Override
-  protected void onProgressUpdate(int[]... values) {
+  protected void onProgressUpdate(long[]... values) {
     super.onProgressUpdate(values);
     mParam.onDownloadProgress.onDownloadProgress(values[0][0], values[0][1]);
   }

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -628,7 +628,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
 
             infoMap.putInt("jobId", jobId);
             infoMap.putInt("statusCode", res.statusCode);
-            infoMap.putInt("bytesWritten", res.bytesWritten);
+            infoMap.putDouble("bytesWritten", (double)res.bytesWritten);
 
             promise.resolve(infoMap);
           } else {
@@ -638,7 +638,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       };
 
       params.onDownloadBegin = new DownloadParams.OnDownloadBegin() {
-        public void onDownloadBegin(int statusCode, int contentLength, Map<String, String> headers) {
+        public void onDownloadBegin(int statusCode, long contentLength, Map<String, String> headers) {
           WritableMap headersMap = Arguments.createMap();
 
           for (Map.Entry<String, String> entry : headers.entrySet()) {
@@ -649,7 +649,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
 
           data.putInt("jobId", jobId);
           data.putInt("statusCode", statusCode);
-          data.putInt("contentLength", contentLength);
+          data.putDouble("contentLength", (double)contentLength);
           data.putMap("headers", headersMap);
 
           sendEvent(getReactApplicationContext(), "DownloadBegin-" + jobId, data);
@@ -657,12 +657,12 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       };
 
       params.onDownloadProgress = new DownloadParams.OnDownloadProgress() {
-        public void onDownloadProgress(int contentLength, int bytesWritten) {
+        public void onDownloadProgress(long contentLength, long bytesWritten) {
           WritableMap data = Arguments.createMap();
 
           data.putInt("jobId", jobId);
-          data.putInt("contentLength", contentLength);
-          data.putInt("bytesWritten", bytesWritten);
+          data.putDouble("contentLength", (double)contentLength);
+          data.putDouble("bytesWritten", (double)bytesWritten);
 
           sendEvent(getReactApplicationContext(), "DownloadProgress-" + jobId, data);
         }


### PR DESCRIPTION
On Android downloadFile will get overflown and contentLength return -1 if downloading large size file over 3GB.
I switched to use `long` instead of `int`; and using getContentLengthLong instead of getContentLength to support big file size.

The content length of the resource that this connection's URL references, -1 if the content length is not known, or if the content length is greater than Integer.MAX_VALUE.
https://docs.oracle.com/javase/7/docs/api/java/net/URLConnection.html#getContentLength()