### PR TITLE
Fix native Windows implementation writeFile

### DIFF
--- a/windows/RNFS/RNFSManager.cs
+++ b/windows/RNFS/RNFSManager.cs
@@ -104,7 +104,7 @@ namespace RNFS
         }
 
         [ReactMethod]
-        public async void writeFile(string filepath, string base64Content, IPromise promise)
+        public async void writeFile(string filepath, string base64Content, JObject _, IPromise promise)
         {
             try
             {


### PR DESCRIPTION
Use the correct parameters for the native Windows implementation of the 'writeFile' function.