### PR TITLE
Update RNFSManager.m

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -813,8 +813,13 @@ RCT_EXPORT_METHOD(copyAssetsVideoIOS: (NSString *) imageUri
   PHAsset *phAsset = [phAssetFetchResult firstObject];
   dispatch_group_t group = dispatch_group_create();
   dispatch_group_enter(group);
+  
+  PHVideoRequestOptions *options = [[PHVideoRequestOptions alloc]init];
+  options.version = PHVideoRequestOptionsVersionOriginal;
+  options.deliveryMode = PHVideoRequestOptionsDeliveryModeAutomatic;
+  options.networkAccessAllowed = YES;
 
-  [[PHImageManager defaultManager] requestAVAssetForVideo:phAsset options:nil resultHandler:^(AVAsset *asset, AVAudioMix *audioMix, NSDictionary *info) {
+  [[PHImageManager defaultManager] requestAVAssetForVideo:phAsset options:options resultHandler:^(AVAsset *asset, AVAudioMix *audioMix, NSDictionary *info) {
 
     if ([asset isKindOfClass:[AVURLAsset class]]) {
       NSURL *url = [(AVURLAsset *)asset URL];


### PR DESCRIPTION
Add options with PHVideoRequestOptionsVersionOriginal version to copyAssetsVideoIOS  to solved assets being nil due to iCloud files.

This commit solves https://github.com/itinance/react-native-fs/issues/572