### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Native filesystem access for react-native
 
 For RN < 0.57 and/or Gradle < 3 you MUST install react-native-fs at version @2.11.17!
 
-For RN >= 0.57 and/or Gradle >= 3 you MUST install react-native-fs at version @2.12!
+For RN >= 0.57 and/or Gradle >= 3 you MUST install react-native-fs at version @2.13.2!
 
 ## Changes for v2.13
 - #544 [Android] Add scanFile method


### PR DESCRIPTION
I installed `react-native-fs@2.12` because of line 9 in this file:

`For RN >= 0.57 and/or Gradle >= 3 you MUST install react-native-fs at version @2.12!`

However, I promptly started hitting the error described in https://github.com/itinance/react-native-fs/issues/602 . Updating to version 2.13.2, as suggested in the issue, solved the error immediately.

This change updates line 9 to advise users to install version 2.13.2 instead of version 2.12.