### PR TITLE
Fix Windows project reference path

### DIFF
--- a/windows/RNFS/RNFS.csproj
+++ b/windows/RNFS/RNFS.csproj
@@ -20,7 +20,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' != 'Development'">
-    <ReactWindowsRoot>..\..</ReactWindowsRoot>
+    <ReactWindowsRoot>..\..\..</ReactWindowsRoot>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -131,7 +131,7 @@
     <EmbeddedResource Include="Properties\RNFS.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
+    <ProjectReference Include="$(ReactWindowsRoot)\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>
     </ProjectReference>

--- a/windows/RNFS/RNFS.csproj
+++ b/windows/RNFS/RNFS.csproj
@@ -131,7 +131,7 @@
     <EmbeddedResource Include="Properties\RNFS.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
+    <ProjectReference Include="..\..\..\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>
     </ProjectReference>


### PR DESCRIPTION
Fixes : https://github.com/itinance/react-native-fs/issues/626

Changed the path to assume that `react-native` and `react-native-fs` are side by side and thus working out the box with an initial install and link.