### PR TITLE
Add null check for getExternalFilesDirs paths

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -898,7 +898,9 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     File[] allExternalFilesDirs = this.getReactApplicationContext().getExternalFilesDirs(null);
     WritableArray fs = Arguments.createArray();
     for (File f : allExternalFilesDirs) {
-      fs.pushString(f.getAbsolutePath());
+      if (f != null) {
+        fs.pushString(f.getAbsolutePath());
+      }
     }
     promise.resolve(fs);
   }


### PR DESCRIPTION
The array returned by `getExternalFilesDirs` [may include null elements](https://developer.android.com/reference/android/content/Context.html#getExternalFilesDirs(java.lang.String)) if the device isn't currently available. If this happens currently, it causes a NullPointerException. This PR adds a null check.

Closes #478