### PR TITLE
#660 add a custom error for cancelled downloadFile Requests

### DIFF
--- a/windows/RNFS/RNFS.csproj
+++ b/windows/RNFS/RNFS.csproj
@@ -126,6 +126,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RequestCancellationException.cs" />
     <Compile Include="RNFSManager.cs" />
     <Compile Include="RNFSPackage.cs" />
     <EmbeddedResource Include="Properties\RNFS.rd.xml" />

--- a/windows/RNFS/RNFSManager.cs
+++ b/windows/RNFS/RNFSManager.cs
@@ -590,6 +590,10 @@ namespace RNFS
                     });
                 }
             }
+            catch (OperationCanceledException ex)
+            {
+                promise.Reject(new RequestCancellationException(jobId, filepath, ex));
+            }
             finally
             {
                 request.Dispose();

--- a/windows/RNFS/RequestCancellationException.cs
+++ b/windows/RNFS/RequestCancellationException.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace RNFS
+{
+    class RequestCancellationException : Exception
+    {
+        protected int jobId;
+        protected string filepath;
+
+        public RequestCancellationException(int jobId, string filepath)
+            : base("CANCELLED: job '" + jobId + "' to file '" + filepath + "'")
+        {
+            this.jobId = jobId;
+            this.filepath = filepath;
+        }
+
+        public RequestCancellationException(int jobId, string filepath, Exception inner)
+            : base("CANCELLED: job '" + jobId + "' to file '" + filepath + "'", inner)
+        {
+            this.jobId = jobId;
+            this.filepath = filepath;
+        }
+
+        public RequestCancellationException(int jobId, string filepath, string message, Exception inner)
+            : base(message, inner)
+        {
+            this.jobId = jobId;
+            this.filepath = filepath;
+        }
+
+        public int getJobId()
+        {
+            return jobId;
+        }
+
+        public string getFilepath()
+        {
+            return filepath;
+        }
+    }
+}


### PR DESCRIPTION
This fixes #660 

There shouldn't be any compatibility issues with android and ios. This just makes the error for cancelled windows requests more specific.