### PR TITLE
note that uploadfiles is not available in the windows version

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ return RNFS.unlink(path)
   });
 ```
 
-### File upload
+### File upload (Android and IOS only)
 
 ```javascript
 // require the module


### PR DESCRIPTION
This makes the Readme more specific. #d7f13fa removed the `(IOS only)` note completely but it should have been changed to (IOS and Android only) because there is still no support for windows.