### PR TITLE
Fix: S3 pre signed uploads or similar binary stream uploads writing corrupt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ android/.gradle/*
 android/gradle/*
 android/*.iml
 android/local.properties
+android/.settings
+android/.project

--- a/FS.common.js
+++ b/FS.common.js
@@ -97,6 +97,7 @@ type DownloadResult = {
 
 type UploadFileOptions = {
   toUrl: string;            // URL to upload file to
+  binaryStreamOnly?: boolean; // Allow for binary data stream for file to be uploaded without extra headers, Default is 'false'
   files: UploadFileItem[];  // An array of objects with the file information to be uploaded.
   headers?: Headers;        // An object of headers to be passed to the server
   fields?: Fields;          // An object of fields to be passed to the server
@@ -565,6 +566,7 @@ var RNFS = {
       jobId: jobId,
       toUrl: options.toUrl,
       files: options.files,
+      binaryStreamOnly: options.binaryStreamOnly || false,
       headers: options.headers || {},
       fields: options.fields || {},
       method: options.method || 'POST'

--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ Read more about background downloads in the [Background Downloads Tutorial (iOS)
 ```
 type UploadFileOptions = {
   toUrl: string;            // URL to upload file to
+  binaryStreamOnly?: boolean// Allow for binary data stream for file to be uploaded without extra headers, Default is 'false'
   files: UploadFileItem[];  // An array of objects with the file information to be uploaded.
   headers?: Headers;        // An object of headers to be passed to the server
   fields?: Fields;          // An object of fields to be passed to the server

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -588,6 +588,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
   NSNumber* jobId = options[@"jobId"];
   params.toUrl = options[@"toUrl"];
   params.files = options[@"files"];
+  params.binaryStreamOnly = options[@"binaryStreamOnly"];
   NSDictionary* headers = options[@"headers"];
   NSDictionary* fields = options[@"fields"];
   NSString* method = options[@"method"];

--- a/Uploader.h
+++ b/Uploader.h
@@ -13,7 +13,8 @@ typedef void (^UploadProgressCallback)(NSNumber*, NSNumber*);
 @property (copy) NSDictionary* headers;
 @property (copy) NSDictionary* fields;
 @property (copy) NSString* method;
-@property (copy) UploadCompleteCallback completeCallback;   // Upload has finished (data written)
+@property (assign) BOOL binaryStreamOnly;
+@property (copy) UploadCompleteCallback completeCallback;    // Upload has finished (data written)
 @property (copy) UploadErrorCallback errorCallback;         // Something gone wrong
 @property (copy) UploadBeginCallback beginCallback;         // Upload has started
 @property (copy) UploadProgressCallback progressCallback;   // Upload is progressing

--- a/Uploader.m
+++ b/Uploader.m
@@ -22,6 +22,7 @@
   NSURL *url = [NSURL URLWithString:_params.toUrl];
   NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
   [req setHTTPMethod:method];
+  BOOL binaryStreamOnly = _params.binaryStreamOnly;
 
   // set headers
   NSString *formBoundaryString = [self generateBoundaryString];
@@ -57,7 +58,6 @@
     [reqBody appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
   }
   NSArray *files = _params.files;
-  Boolean hasMultipleFiles = [files count] > 1;
   // add files
   for (NSDictionary *file in files) {
     NSString *name = file[@"name"];
@@ -75,7 +75,7 @@
     }
 
     NSData *fileData = [NSData dataWithContentsOfFile:filepath];
-    if (hasMultipleFiles) {
+    if (!binaryStreamOnly) {
       [reqBody appendData:formBoundaryData];
       [reqBody appendData:[[NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@\"\r\n", name.length ? name : filename, filename] dataUsingEncoding:NSUTF8StringEncoding]];
 
@@ -88,12 +88,12 @@
     }
   
     [reqBody appendData:fileData];
-    if (hasMultipleFiles) {
+    if (!binaryStreamOnly) {
       [reqBody appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
     }
   }
 
-  if (hasMultipleFiles) {
+  if (!binaryStreamOnly) {
     // add end boundary
     NSData* end = [[NSString stringWithFormat:@"--%@--\r\n", formBoundaryString] dataUsingEncoding:NSUTF8StringEncoding];
     [reqBody appendData:end];

--- a/Uploader.m
+++ b/Uploader.m
@@ -56,9 +56,10 @@
     [reqBody appendData:[val dataUsingEncoding:NSUTF8StringEncoding]];
     [reqBody appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
   }
-
+  NSArray *files = _params.files;
+  Boolean hasMultipleFiles = [files count] > 1;
   // add files
-  for (NSDictionary *file in _params.files) {
+  for (NSDictionary *file in files) {
     NSString *name = file[@"name"];
     NSString *filename = file[@"filename"];
     NSString *filepath = file[@"filepath"];
@@ -74,24 +75,29 @@
     }
 
     NSData *fileData = [NSData dataWithContentsOfFile:filepath];
+    if (hasMultipleFiles) {
+      [reqBody appendData:formBoundaryData];
+      [reqBody appendData:[[NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@\"\r\n", name.length ? name : filename, filename] dataUsingEncoding:NSUTF8StringEncoding]];
 
-    [reqBody appendData:formBoundaryData];
-    [reqBody appendData:[[NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@\"\r\n", name.length ? name : filename, filename] dataUsingEncoding:NSUTF8StringEncoding]];
-
-    if (filetype) {
-      [reqBody appendData:[[NSString stringWithFormat:@"Content-Type: %@\r\n", filetype] dataUsingEncoding:NSUTF8StringEncoding]];
-    } else {
-      [reqBody appendData:[[NSString stringWithFormat:@"Content-Type: %@\r\n", [self mimeTypeForPath:filename]] dataUsingEncoding:NSUTF8StringEncoding]];
+      if (filetype) {
+        [reqBody appendData:[[NSString stringWithFormat:@"Content-Type: %@\r\n", filetype] dataUsingEncoding:NSUTF8StringEncoding]];
+      } else {
+        [reqBody appendData:[[NSString stringWithFormat:@"Content-Type: %@\r\n", [self mimeTypeForPath:filename]] dataUsingEncoding:NSUTF8StringEncoding]];
+      }
+      [reqBody appendData:[[NSString stringWithFormat:@"Content-Length: %ld\r\n\r\n", (long)[fileData length]] dataUsingEncoding:NSUTF8StringEncoding]];
     }
-
-    [reqBody appendData:[[NSString stringWithFormat:@"Content-Length: %ld\r\n\r\n", (long)[fileData length]] dataUsingEncoding:NSUTF8StringEncoding]];
+  
     [reqBody appendData:fileData];
-    [reqBody appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    if (hasMultipleFiles) {
+      [reqBody appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    }
   }
 
-  // add end boundary
-  NSData* end = [[NSString stringWithFormat:@"--%@--\r\n", formBoundaryString] dataUsingEncoding:NSUTF8StringEncoding];
-  [reqBody appendData:end];
+  if (hasMultipleFiles) {
+    // add end boundary
+    NSData* end = [[NSString stringWithFormat:@"--%@--\r\n", formBoundaryString] dataUsingEncoding:NSUTF8StringEncoding];
+    [reqBody appendData:end];
+  }
 
   // send request
   [req setHTTPBody:reqBody];

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -784,6 +784,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       ReadableMap headers = options.getMap("headers");
       ReadableMap fields = options.getMap("fields");
       String method = options.getString("method");
+      boolean binaryStreamOnly = options.getBoolean("binaryStreamOnly");
       ArrayList<ReadableMap> fileList = new ArrayList<>();
       UploadParams params = new UploadParams();
       for(int i =0;i<files.size();i++){
@@ -792,8 +793,9 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       params.src = url;
       params.files =fileList;
       params.headers = headers;
-      params.method=method;
-      params.fields=fields;
+      params.method = method;
+      params.fields = fields;
+      params.binaryStreamOnly = binaryStreamOnly;
       params.onUploadComplete = new UploadParams.onUploadComplete() {
         public void onUploadComplete(UploadResult res) {
           if (res.exception == null) {

--- a/android/src/main/java/com/rnfs/UploadParams.java
+++ b/android/src/main/java/com/rnfs/UploadParams.java
@@ -17,6 +17,7 @@ public class UploadParams {
     }
     public URL src;
     public ArrayList<ReadableMap> files;
+    public boolean binaryStreamOnly;
     public String name;
     public ReadableMap headers;
     public ReadableMap fields;

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ type DownloadResult = {
 
 type UploadFileOptions = {
 	toUrl: string // URL to upload file to
+	binaryStreamOnly?: boolean // Allow for binary data stream for file to be uploaded without extra headers, Default is 'false'
 	files: UploadFileItem[] // An array of objects with the file information to be uploaded.
 	headers?: Headers // An object of headers to be passed to the server
 	fields?: Fields // An object of fields to be passed to the server


### PR DESCRIPTION
## Background
RNFS is a great library to download and upload files. While trying to upload a file to S3 using a PreSigned `PUT` url, it was writing corrupt files as it was adding form boundary, meta data, etc to the file.

## Fix
`binaryStreamOnly`: A newly added field in `UploadFileOptions` which is defaulted to `false`.
If this options is set `true` the uploader for RNFS will only write file binary data to the directed upload url. It omits all the meta data and form boundaries as they will write to the uploading stream essentially writing a corrupt file for the format provided. 
