### PR TITLE
bugfix #443: Add option progressInterval for downloadFile

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -19,6 +19,7 @@ typedef void (^ResumableCallback)();
 @property        bool background;                             // Whether to continue download when app is in background
 @property        bool discretionary;                          // Whether the file may be downloaded at the OS's discretion (iOS only)
 @property        bool cacheable;                              // Whether the file may be stored in the shared NSURLCache (iOS only)
+@property (copy) NSNumber* progressInterval;
 @property (copy) NSNumber* progressDivider;
 @property (copy) NSNumber* readTimeout;
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -11,6 +11,7 @@
 @property (retain) NSURLSession* session;
 @property (retain) NSURLSessionDownloadTask* task;
 @property (retain) NSNumber* statusCode;
+@property (assign) NSTimeInterval lastProgressEmitTimestamp;
 @property (retain) NSNumber* lastProgressValue;
 @property (retain) NSNumber* contentLength;
 @property (retain) NSNumber* bytesWritten;
@@ -28,6 +29,7 @@
     
     _params = params;
 
+  _lastProgressEmitTimestamp = 0;
   _bytesWritten = 0;
 
   NSURL* url = [NSURL URLWithString:_params.fromUrl];
@@ -81,7 +83,13 @@
   if ([_statusCode isEqualToNumber:[NSNumber numberWithInt:200]]) {
     _bytesWritten = @(totalBytesWritten);
 
-    if (_params.progressDivider.integerValue <= 0) {
+    if(_params.progressInterval.integerValue > 0){
+      NSTimeInterval timestamp = [[NSDate date] timeIntervalSince1970];
+      if(timestamp - _lastProgressEmitTimestamp > _params.progressInterval.integerValue / 1000.0){
+        _lastProgressEmitTimestamp = timestamp;
+        return _params.progressCallback(_contentLength, _bytesWritten);
+      }
+    }else if (_params.progressDivider.integerValue <= 0) {
       return _params.progressCallback(_contentLength, _bytesWritten);
     } else {
       double doubleBytesWritten = (double)[_bytesWritten longValue];

--- a/FS.common.js
+++ b/FS.common.js
@@ -68,6 +68,7 @@ type DownloadFileOptions = {
   background?: boolean;     // Continue the download in the background after the app terminates (iOS only)
   discretionary?: boolean;  // Allow the OS to control the timing and speed of the download to improve perceived performance  (iOS only)
   cacheable?: boolean;      // Whether the download can be stored in the shared NSURLCache (iOS only)
+  progressInterval?: number;
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;
@@ -487,6 +488,7 @@ var RNFS = {
     if (options.headers && typeof options.headers !== 'object') throw new Error('downloadFile: Invalid value for property `headers`');
     if (options.background && typeof options.background !== 'boolean') throw new Error('downloadFile: Invalid value for property `background`');
     if (options.progressDivider && typeof options.progressDivider !== 'number') throw new Error('downloadFile: Invalid value for property `progressDivider`');
+    if (options.progressInterval && typeof options.progressInterval !== 'number') throw new Error('downloadFile: Invalid value for property `progressInterval`');
     if (options.readTimeout && typeof options.readTimeout !== 'number') throw new Error('downloadFile: Invalid value for property `readTimeout`');
     if (options.connectionTimeout && typeof options.connectionTimeout !== 'number') throw new Error('downloadFile: Invalid value for property `connectionTimeout`');
 
@@ -512,6 +514,7 @@ var RNFS = {
       headers: options.headers || {},
       background: !!options.background,
       progressDivider: options.progressDivider || 0,
+      progressInterval: options.progressInterval || 0,
       readTimeout: options.readTimeout || 15000,
       connectionTimeout: options.connectionTimeout || 5000
     };

--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ type DownloadFileOptions = {
   background?: boolean;     // Continue the download in the background after the app terminates (iOS only)
   discretionary?: boolean;  // Allow the OS to control the timing and speed of the download to improve perceived performance  (iOS only)
   cacheable?: boolean;      // Whether the download can be stored in the shared NSURLCache (iOS only, defaults to true)
+  progressInterval?: number;
   progressDivider?: number;
   begin?: (res: DownloadBeginCallbackResult) => void;
   progress?: (res: DownloadProgressCallbackResult) => void;
@@ -543,6 +544,9 @@ type DownloadProgressCallbackResult = {
   bytesWritten: number;   // The number of bytes written to the file so far
 };
 ```
+
+If `options.progressInterval` is provided, it will return progress events in the maximum frequency of `progressDivider`.
+For example, if `progressInterval` = 100, you will not receive callbacks more often than every 100th millisecond.
 
 If `options.progressDivider` is provided, it will return progress events that divided by `progressDivider`.
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -469,6 +469,8 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   params.discretionary = [discretionary boolValue];
   NSNumber* cacheable = options[@"cacheable"];
   params.cacheable = cacheable ? [cacheable boolValue] : YES;
+  NSNumber* progressInterval= options[@"progressInterval"];
+  params.progressInterval = progressInterval;
   NSNumber* progressDivider = options[@"progressDivider"];
   params.progressDivider = progressDivider;
   NSNumber* readTimeout = options[@"readTimeout"];

--- a/android/src/main/java/com/rnfs/DownloadParams.java
+++ b/android/src/main/java/com/rnfs/DownloadParams.java
@@ -22,6 +22,7 @@ public class DownloadParams {
   public URL src;
   public File dest;
   public ReadableMap headers;
+  public int progressInterval;
   public float progressDivider;
   public int readTimeout;
   public int connectionTimeout;

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -699,6 +699,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       URL url = new URL(options.getString("fromUrl"));
       final int jobId = options.getInt("jobId");
       ReadableMap headers = options.getMap("headers");
+      int progressInterval = options.getInt("progressInterval");
       int progressDivider = options.getInt("progressDivider");
       int readTimeout = options.getInt("readTimeout");
       int connectionTimeout = options.getInt("connectionTimeout");
@@ -708,6 +709,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       params.src = url;
       params.dest = file;
       params.headers = headers;
+      params.progressInterval = progressInterval;
       params.progressDivider = progressDivider;
       params.readTimeout = readTimeout;
       params.connectionTimeout = connectionTimeout;

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ type DownloadFileOptions = {
 	background?: boolean // Continue the download in the background after the app terminates (iOS only)
 	discretionary?: boolean // Allow the OS to control the timing and speed of the download to improve perceived performance  (iOS only)
 	cacheable?: boolean // Whether the download can be stored in the shared NSURLCache (iOS only)
+	progressInterval: number
 	progressDivider?: number
 	begin?: (res: DownloadBeginCallbackResult) => void
 	progress?: (res: DownloadProgressCallbackResult) => void


### PR DESCRIPTION
Hello,

Option _progressDivider_ do not work if the server does not provide response content length. To reduce the frequency of callbacks, the option _progressInterval_ defines how often the progress is returned.