### PR TITLE
Add tvOS deployment target to podspec

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.author          = { "Johannes Lumpe" => "johannes@lum.pe" }
   
   s.ios.deployment_target = '7.0'
+  s.tvos.deployment_target = '9.2'
 
   s.source          = { :git => "https://github.com/itinance/react-native-fs", :tag => "v#{s.version}" }
   s.source_files    = '*.{h,m}'


### PR DESCRIPTION
RN 0.60+ now has auto-linking via cocoapods. This adds the tvOS deployment target so the pod will correctly install on tvOS.