### PR TITLE
Support iOS background download timeout

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -20,7 +20,8 @@ typedef void (^ResumableCallback)();
 @property        bool discretionary;                          // Whether the file may be downloaded at the OS's discretion (iOS only)
 @property        bool cacheable;                              // Whether the file may be stored in the shared NSURLCache (iOS only)
 @property (copy) NSNumber* progressDivider;
-@property (copy) NSNumber* readTimeout;
+@property (copy) NSNumber* readTimeout;                       // How long (in milliseconds) a task should wait for additional data to arrive before giving up
+@property (copy) NSNumber* backgroundTimeout;                 // How long (in milliseconds) to wait for an entire resource to transfer before giving up
 
 
 @end

--- a/Downloader.m
+++ b/Downloader.m
@@ -61,6 +61,7 @@
 
   config.HTTPAdditionalHeaders = _params.headers;
   config.timeoutIntervalForRequest = [_params.readTimeout intValue] / 1000.0;
+  config.timeoutIntervalForResource = [_params.backgroundTimeout intValue] / 1000.0;
 
   _session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
   _task = [_session downloadTaskWithURL:url];

--- a/FS.common.js
+++ b/FS.common.js
@@ -74,6 +74,7 @@ type DownloadFileOptions = {
   resumable?: () => void;    // only supported on iOS yet
   connectionTimeout?: number; // only supported on Android yet
   readTimeout?: number;       // supported on Android and iOS
+  backgroundTimeout?: number; // Maximum time (in milliseconds) to download an entire resource (iOS only, useful for timing out background downloads)
 };
 
 type DownloadBeginCallbackResult = {
@@ -489,6 +490,7 @@ var RNFS = {
     if (options.progressDivider && typeof options.progressDivider !== 'number') throw new Error('downloadFile: Invalid value for property `progressDivider`');
     if (options.readTimeout && typeof options.readTimeout !== 'number') throw new Error('downloadFile: Invalid value for property `readTimeout`');
     if (options.connectionTimeout && typeof options.connectionTimeout !== 'number') throw new Error('downloadFile: Invalid value for property `connectionTimeout`');
+    if (options.backgroundTimeout && typeof options.backgroundTimeout !== 'number') throw new Error('downloadFile: Invalid value for property `backgroundTimeout`');
 
     var jobId = getJobId();
     var subscriptions = [];
@@ -513,7 +515,8 @@ var RNFS = {
       background: !!options.background,
       progressDivider: options.progressDivider || 0,
       readTimeout: options.readTimeout || 15000,
-      connectionTimeout: options.connectionTimeout || 5000
+      connectionTimeout: options.connectionTimeout || 5000,
+      backgroundTimeout: options.backgroundTimeout || 3600000 // 1 hour
     };
 
     return {

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ type DownloadFileOptions = {
   resumable?: () => void;    // only supported on iOS yet
   connectionTimeout?: number // only supported on Android yet
   readTimeout?: number       // supported on Android and iOS
+  backgroundTimeout?: number // Maximum time (in milliseconds) to download an entire resource (iOS only, useful for timing out background downloads)
 };
 ```
 ```

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -473,6 +473,8 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   params.progressDivider = progressDivider;
   NSNumber* readTimeout = options[@"readTimeout"];
   params.readTimeout = readTimeout;
+  NSNumber* backgroundTimeout = options[@"backgroundTimeout"];
+  params.backgroundTimeout = backgroundTimeout;
 
   __block BOOL callbackFired = NO;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ type DownloadFileOptions = {
 	resumable?: () => void // only supported on iOS yet
 	connectionTimeout?: number // only supported on Android yet
 	readTimeout?: number // supported on Android and iOS
+	backgroundTimeout?: number // Maximum time (in milliseconds) to download an entire resource (iOS only, useful for timing out background downloads)
 }
 
 type DownloadBeginCallbackResult = {


### PR DESCRIPTION
This PR adds the ability to timeout iOS background downloads.

Currently the only way to timeout iOS downloads is the `readTimeout` option, but this isn't working for background downloads. `readTimeout` uses [timeoutIntervalForRequest](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408259-timeoutintervalforrequest?language=objc) under the hood, but since download tasks created by a background session are automatically retried (up to 7 days) if failed due to a timeout, the exception thrown by `readTimeout` is ignored in background mode.

By adding the `backgroundTimeout` option to `downloadFile`, which uses [timeoutIntervalForResource](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408153-timeoutintervalforresource?language=objc#declarations) under the hood, now we have a way to timeout background downloads.

[`timeoutIntervalForRequest` vs `timeoutIntervalForResource`](https://github.com/Alamofire/Alamofire/issues/1266#issuecomment-221471947)

Fixes: #656