### PR TITLE
iOS: Fix binaryStreamOnly not properly being converted from NSNumber to BOOL

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -588,7 +588,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
   NSNumber* jobId = options[@"jobId"];
   params.toUrl = options[@"toUrl"];
   params.files = options[@"files"];
-  params.binaryStreamOnly = options[@"binaryStreamOnly"];
+  params.binaryStreamOnly = [options[@"binaryStreamOnly"] boolValue];
   NSDictionary* headers = options[@"headers"];
   NSDictionary* fields = options[@"fields"];
   NSString* method = options[@"method"];


### PR DESCRIPTION
iOS: Fix binaryStreamOnly not properly being converted from NSNumber to BOOL
binaryStreamOnly was always true