### PR TITLE
Fix for issue #749: RNFS.uploadFiles upload raw not multipart

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -588,7 +588,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
   NSNumber* jobId = options[@"jobId"];
   params.toUrl = options[@"toUrl"];
   params.files = options[@"files"];
-  params.binaryStreamOnly = options[@"binaryStreamOnly"];
+  params.binaryStreamOnly = [options[@"binaryStreamOnly"] boolValue];
   NSDictionary* headers = options[@"headers"];
   NSDictionary* fields = options[@"fields"];
   NSString* method = options[@"method"];


### PR DESCRIPTION
The RCT_EXPORT_METHOD for uploadFiles was casting the config option of binaryStreamOnly to it's internal params. The option comes through as an NSNumber as with all boolean primitives via the RCT methods. In objective-c comparing a NSNumber to a BOOL directly will do a pointer comparison, meaning that it will always be true if anything is set (eg: 0, 1, 999, fizzbuzz, as long as it's an object, the pointer will be true). To fix this you need to use the boolValue method on NSNumber to return a BOOL that matches the original intent.

See: https://github.com/itinance/react-native-fs/issues/749