### PR TITLE
Add conditional comments around methods not supported in Mac Catalyst

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -708,6 +708,8 @@ RCT_EXPORT_METHOD(getFSInfo:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromise
 }
 
 
+// [PHAsset fetchAssetsWithALAssetURLs] is deprecated and not supported in Mac Catalyst
+#if !TARGET_OS_UIKITFORMAC
 /**
  * iOS Only: copy images from the assets-library (camera-roll) to a specific path, asuming
  * JPEG-Images.
@@ -796,7 +798,10 @@ RCT_EXPORT_METHOD(copyAssetsFileIOS: (NSString *) imageUri
         }
     }];
 }
+#endif
 
+// [PHAsset fetchAssetsWithALAssetURLs] is deprecated and not supported in Mac Catalyst
+#if !TARGET_OS_UIKITFORMAC
 /**
  * iOS Only: copy videos from the assets-library (camera-roll) to a specific path as mp4-file.
  *
@@ -849,6 +854,7 @@ RCT_EXPORT_METHOD(copyAssetsVideoIOS: (NSString *) imageUri
 
   return resolve(destination);
 }
+#endif
 
 RCT_EXPORT_METHOD(touch:(NSString*)filepath
                   mtime:(NSDate *)mtime


### PR DESCRIPTION
I've successfully built and used `react-native-fs` on macOS 10.15 with the just-released Mac Catalyst. 🎉 

There was one slight issue: a couple of methods rely on deprecated iOS APIs (see https://developer.apple.com/documentation/photokit/phasset/1624782-fetchassetswithalasseturls). These APIs aren't supported under Mac Catalyst.

I don't know if it's worth fixing the methods (haven't used them myself), but at least there's an easy way to exclude them from the Catalyst build with conditional comments.

Thanks!