### PR TITLE
Import RCTImageLoaderProtocol instead of RCTImageLoader to fix iOS build on RN>0.60

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -14,7 +14,7 @@
 
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
-#import <React/RCTImageLoader.h>
+#import <React/RCTImageLoaderProtocol.h>
 
 #import <CommonCrypto/CommonDigest.h>
 #import <Photos/Photos.h>


### PR DESCRIPTION
iOS is unable to build with RN>0.60 as RNFS is unable to import RCTImageLoader:

![image](https://user-images.githubusercontent.com/13544531/66906754-1ab13c80-f000-11e9-897b-8adebe69491f.png)

This PR implements the fix suggested on this open issue:
https://github.com/itinance/react-native-fs/issues/768