### PR TITLE
Pass empty callbacks to emitters in the event of no parameters

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -548,17 +548,16 @@ var RNFS = {
     if (options.fields && typeof options.fields !== 'object') throw new Error('uploadFiles: Invalid value for property `fields`');
     if (options.method && typeof options.method !== 'string') throw new Error('uploadFiles: Invalid value for property `method`');
 
-    if (options.begin) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.begin));
-    }
+    
+    subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.begin || function() {}));
+    
     if (options.beginCallback && options.beginCallback instanceof Function) {
       // Deprecated
       subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.beginCallback));
     }
 
-    if (options.progress) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progress));
-    }
+    subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progress || function() {}));
+
     if (options.progressCallback && options.progressCallback instanceof Function) {
       // Deprecated
       subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progressCallback));

--- a/FS.common.js
+++ b/FS.common.js
@@ -499,17 +499,11 @@ var RNFS = {
     var jobId = getJobId();
     var subscriptions = [];
 
-    if (options.begin) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', options.begin));
-    }
+    subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', options.begin || function() {}));
 
-    if (options.progress) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', options.progress));
-    }
+    subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', options.progress || function() {}));
 
-    if (options.resumable) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', options.resumable));
-    }
+    subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', options.resumable || function() {}));
 
     var bridgeOptions = {
       jobId: jobId,


### PR DESCRIPTION
Should fix #788 issue with event emitter warnings when there are no listeners by passing empty callbacks.