### PR TITLE
Improve implementation related to event callbacks

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -499,11 +499,17 @@ var RNFS = {
     var jobId = getJobId();
     var subscriptions = [];
 
-    subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', options.begin || function() {}));
+    if (options.begin) {
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', options.begin));
+    }
 
-    subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', options.progress || function() {}));
+    if (options.progress) {
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', options.progress));
+    }
 
-    subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', options.resumable || function() {}));
+    if (options.resumable) {
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', options.resumable));
+    }
 
     var bridgeOptions = {
       jobId: jobId,
@@ -515,7 +521,10 @@ var RNFS = {
       progressInterval: options.progressInterval || 0,
       readTimeout: options.readTimeout || 15000,
       connectionTimeout: options.connectionTimeout || 5000,
-      backgroundTimeout: options.backgroundTimeout || 3600000 // 1 hour
+      backgroundTimeout: options.backgroundTimeout || 3600000, // 1 hour
+      hasBeginCallback: options.begin instanceof Function,
+      hasProgressCallback: options.progress instanceof Function,
+      hasResumableCallback: options.resumable instanceof Function,
     };
 
     return {
@@ -548,17 +557,16 @@ var RNFS = {
     if (options.fields && typeof options.fields !== 'object') throw new Error('uploadFiles: Invalid value for property `fields`');
     if (options.method && typeof options.method !== 'string') throw new Error('uploadFiles: Invalid value for property `method`');
 
-    
-    subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.begin || function() {}));
-    
-    if (options.beginCallback && options.beginCallback instanceof Function) {
+    if (options.begin) {
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.begin));
+    } else if (options.beginCallback) {
       // Deprecated
       subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.beginCallback));
     }
 
-    subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progress || function() {}));
-
-    if (options.progressCallback && options.progressCallback instanceof Function) {
+    if (options.progress) {
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progress));
+    } else if (options.progressCallback) {
       // Deprecated
       subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progressCallback));
     }
@@ -570,7 +578,9 @@ var RNFS = {
       binaryStreamOnly: options.binaryStreamOnly || false,
       headers: options.headers || {},
       fields: options.fields || {},
-      method: options.method || 'POST'
+      method: options.method || 'POST',
+      hasBeginCallback: options.begin instanceof Function || options.beginCallback instanceof Function,
+      hasProgressCallback: options.progress instanceof Function || options.progressCallback instanceof Function,
     };
 
     return {

--- a/Uploader.m
+++ b/Uploader.m
@@ -86,7 +86,7 @@
       }
       [reqBody appendData:[[NSString stringWithFormat:@"Content-Length: %ld\r\n\r\n", (long)[fileData length]] dataUsingEncoding:NSUTF8StringEncoding]];
     }
-  
+
     [reqBody appendData:fileData];
     if (!binaryStreamOnly) {
       [reqBody appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
@@ -109,7 +109,9 @@
       return self->_params.completeCallback(str, response);
   }];
   [_task resume];
-  _params.beginCallback();
+  if (_params.beginCallback) {
+    _params.beginCallback();
+  }
 }
 
 - (NSString *)generateBoundaryString
@@ -139,7 +141,9 @@
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(NSInteger)totalBytesExpectedToSend
 {
-  return _params.progressCallback([NSNumber numberWithLongLong:totalBytesExpectedToSend], [NSNumber numberWithLongLong:totalBytesSent]);
+  if (_params.progressCallback) {
+    _params.progressCallback([NSNumber numberWithLongLong:totalBytesExpectedToSend], [NSNumber numberWithLongLong:totalBytesSent]);
+  }
 }
 
 - (void)stopUpload

--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -97,7 +97,9 @@ public class Downloader extends AsyncTask<DownloadParams, long[], DownloadResult
           }
         }
 
-        mParam.onDownloadBegin.onDownloadBegin(statusCode, lengthOfFile, headersFlat);
+        if (mParam.onDownloadBegin != null) {
+          mParam.onDownloadBegin.onDownloadBegin(statusCode, lengthOfFile, headersFlat);
+        }
 
         input = new BufferedInputStream(connection.getInputStream(), 8 * 1024);
         output = new FileOutputStream(param.dest);
@@ -107,29 +109,34 @@ public class Downloader extends AsyncTask<DownloadParams, long[], DownloadResult
         int count;
         double lastProgressValue = 0;
         long lastProgressEmitTimestamp = 0;
+        boolean hasProgressCallback = mParam.onDownloadProgress != null;
 
         while ((count = input.read(data)) != -1) {
           if (mAbort.get()) throw new Exception("Download has been aborted");
 
           total += count;
-          if (param.progressInterval > 0) {
-            long timestamp = System.currentTimeMillis();
-            if (timestamp - lastProgressEmitTimestamp > param.progressInterval) {
-              lastProgressEmitTimestamp = timestamp;
-              publishProgress(new long[]{lengthOfFile, total});
-            }
-          } else if (param.progressDivider <= 0) {
-            publishProgress(new long[]{lengthOfFile, total});
-          } else {
-            double progress = Math.round(((double) total * 100) / lengthOfFile);
-            if (progress % param.progressDivider == 0) {
-              if ((progress != lastProgressValue) || (total == lengthOfFile)) {
-                Log.d("Downloader", "EMIT: " + String.valueOf(progress) + ", TOTAL:" + String.valueOf(total));
-                lastProgressValue = progress;
+
+          if (hasProgressCallback) {
+            if (param.progressInterval > 0) {
+              long timestamp = System.currentTimeMillis();
+              if (timestamp - lastProgressEmitTimestamp > param.progressInterval) {
+                lastProgressEmitTimestamp = timestamp;
                 publishProgress(new long[]{lengthOfFile, total});
+              }
+            } else if (param.progressDivider <= 0) {
+              publishProgress(new long[]{lengthOfFile, total});
+            } else {
+              double progress = Math.round(((double) total * 100) / lengthOfFile);
+              if (progress % param.progressDivider == 0) {
+                if ((progress != lastProgressValue) || (total == lengthOfFile)) {
+                  Log.d("Downloader", "EMIT: " + String.valueOf(progress) + ", TOTAL:" + String.valueOf(total));
+                  lastProgressValue = progress;
+                  publishProgress(new long[]{lengthOfFile, total});
+                }
               }
             }
           }
+
           output.write(data, 0, count);
         }
 
@@ -158,7 +165,9 @@ public class Downloader extends AsyncTask<DownloadParams, long[], DownloadResult
   @Override
   protected void onProgressUpdate(long[]... values) {
     super.onProgressUpdate(values);
-    mParam.onDownloadProgress.onDownloadProgress(values[0][0], values[0][1]);
+    if (mParam.onDownloadProgress != null) {
+      mParam.onDownloadProgress.onDownloadProgress(values[0][0], values[0][1]);
+    }
   }
 
   protected void onPostExecute(Exception ex) {

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -702,6 +702,8 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       int progressDivider = options.getInt("progressDivider");
       int readTimeout = options.getInt("readTimeout");
       int connectionTimeout = options.getInt("connectionTimeout");
+      boolean hasBeginCallback = options.getBoolean("hasBeginCallback");
+      boolean hasProgressCallback = options.getBoolean("hasProgressCallback");
 
       DownloadParams params = new DownloadParams();
 
@@ -729,36 +731,40 @@ public class RNFSManager extends ReactContextBaseJavaModule {
         }
       };
 
-      params.onDownloadBegin = new DownloadParams.OnDownloadBegin() {
-        public void onDownloadBegin(int statusCode, long contentLength, Map<String, String> headers) {
-          WritableMap headersMap = Arguments.createMap();
+      if (hasBeginCallback) {
+        params.onDownloadBegin = new DownloadParams.OnDownloadBegin() {
+          public void onDownloadBegin(int statusCode, long contentLength, Map<String, String> headers) {
+            WritableMap headersMap = Arguments.createMap();
 
-          for (Map.Entry<String, String> entry : headers.entrySet()) {
-            headersMap.putString(entry.getKey(), entry.getValue());
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+              headersMap.putString(entry.getKey(), entry.getValue());
+            }
+
+            WritableMap data = Arguments.createMap();
+
+            data.putInt("jobId", jobId);
+            data.putInt("statusCode", statusCode);
+            data.putDouble("contentLength", (double)contentLength);
+            data.putMap("headers", headersMap);
+
+            sendEvent(getReactApplicationContext(), "DownloadBegin", data);
           }
+        };
+      }
 
-          WritableMap data = Arguments.createMap();
+      if (hasProgressCallback) {
+        params.onDownloadProgress = new DownloadParams.OnDownloadProgress() {
+          public void onDownloadProgress(long contentLength, long bytesWritten) {
+            WritableMap data = Arguments.createMap();
 
-          data.putInt("jobId", jobId);
-          data.putInt("statusCode", statusCode);
-          data.putDouble("contentLength", (double)contentLength);
-          data.putMap("headers", headersMap);
+            data.putInt("jobId", jobId);
+            data.putDouble("contentLength", (double)contentLength);
+            data.putDouble("bytesWritten", (double)bytesWritten);
 
-          sendEvent(getReactApplicationContext(), "DownloadBegin", data);
-        }
-      };
-
-      params.onDownloadProgress = new DownloadParams.OnDownloadProgress() {
-        public void onDownloadProgress(long contentLength, long bytesWritten) {
-          WritableMap data = Arguments.createMap();
-
-          data.putInt("jobId", jobId);
-          data.putDouble("contentLength", (double)contentLength);
-          data.putDouble("bytesWritten", (double)bytesWritten);
-
-          sendEvent(getReactApplicationContext(), "DownloadProgress", data);
-        }
-      };
+            sendEvent(getReactApplicationContext(), "DownloadProgress", data);
+          }
+        };
+      }
 
       Downloader downloader = new Downloader();
 
@@ -790,6 +796,9 @@ public class RNFSManager extends ReactContextBaseJavaModule {
       ReadableMap fields = options.getMap("fields");
       String method = options.getString("method");
       boolean binaryStreamOnly = options.getBoolean("binaryStreamOnly");
+      boolean hasBeginCallback = options.getBoolean("hasBeginCallback");
+      boolean hasProgressCallback = options.getBoolean("hasProgressCallback");
+
       ArrayList<ReadableMap> fileList = new ArrayList<>();
       UploadParams params = new UploadParams();
       for(int i =0;i<files.size();i++){
@@ -817,27 +826,31 @@ public class RNFSManager extends ReactContextBaseJavaModule {
         }
       };
 
-      params.onUploadBegin = new UploadParams.onUploadBegin() {
-        public void onUploadBegin() {
-          WritableMap data = Arguments.createMap();
+      if (hasBeginCallback) {
+        params.onUploadBegin = new UploadParams.onUploadBegin() {
+          public void onUploadBegin() {
+            WritableMap data = Arguments.createMap();
 
-          data.putInt("jobId", jobId);
+            data.putInt("jobId", jobId);
 
-          sendEvent(getReactApplicationContext(), "UploadBegin", data);
-        }
-      };
+            sendEvent(getReactApplicationContext(), "UploadBegin", data);
+          }
+        };
+      }
 
-      params.onUploadProgress = new UploadParams.onUploadProgress() {
-        public void onUploadProgress(int totalBytesExpectedToSend,int totalBytesSent) {
-          WritableMap data = Arguments.createMap();
+      if (hasProgressCallback) {
+        params.onUploadProgress = new UploadParams.onUploadProgress() {
+          public void onUploadProgress(int totalBytesExpectedToSend,int totalBytesSent) {
+            WritableMap data = Arguments.createMap();
 
-          data.putInt("jobId", jobId);
-          data.putInt("totalBytesExpectedToSend", totalBytesExpectedToSend);
-          data.putInt("totalBytesSent", totalBytesSent);
+            data.putInt("jobId", jobId);
+            data.putInt("totalBytesExpectedToSend", totalBytesExpectedToSend);
+            data.putInt("totalBytesSent", totalBytesSent);
 
-          sendEvent(getReactApplicationContext(), "UploadProgress", data);
-        }
-      };
+            sendEvent(getReactApplicationContext(), "UploadProgress", data);
+          }
+        };
+      }
 
       Uploader uploader = new Uploader();
 

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -114,7 +114,9 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 fileCount++;
             }
             fileCount = 0;
-            mParams.onUploadBegin.onUploadBegin();
+            if (mParams.onUploadBegin != null) {
+                mParams.onUploadBegin.onUploadBegin();
+            }
             if (!binaryStreamOnly) {
                 long requestLength = totalFileLength;
                 requestLength += stringData.length() + files.length * crlf.length();
@@ -130,7 +132,7 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
 
             byteSentTotal = 0;
             Runtime run = Runtime.getRuntime();
-            
+
             for (ReadableMap map : params.files) {
                 if (!binaryStreamOnly) {
                     request.writeBytes(fileHeader[fileCount]);
@@ -146,8 +148,10 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 byte[] buffer = new byte[buffer_size];
                 while ((bytes_read = bufInput.read(buffer)) != -1) {
                     request.write(buffer, 0, bytes_read);
-                    byteSentTotal += bytes_read;
-                    mParams.onUploadProgress.onUploadProgress((int) totalFileLength, byteSentTotal);
+                    if (mParams.onUploadProgress != null) {
+                        byteSentTotal += bytes_read;
+                        mParams.onUploadProgress.onUploadProgress((int) totalFileLength, byteSentTotal);
+                    }
                 }
                 if (!binaryStreamOnly) {
                     request.writeBytes(crlf);


### PR DESCRIPTION
It's related to #790, #788

I think this implementation is better than passing empty callbacks.
In most cases where no events are required, works more efficiently on both Android and iOS.
As you know, performance is improved because unnecessary bridge communication is reduced.

I hope this helps.
