### PR TITLE
added hint on read me to prevent breaking android

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install react-native-fs@2.0.1-rc.2 --save
 As @a-koka pointed out, you should then update your package.json to
 `"react-native-fs": "2.0.1-rc.2"` (without the tilde)
 
-### Adding automatically with react-native link
+### Adding automatically with react-native link ( For RN < 0.60 )
 
 At the command line, in your project folder, type:
 


### PR DESCRIPTION
For RN >= 0.60 if you use react-native link after yarn add will cause build.gradel to be mis configured and build fail