### PR TITLE
Should not send tail string for binaryStreamOnly option on Android

### DIFF
--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -159,7 +159,9 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 fileCount++;
                 bufInput.close();
             }
-            request.writeBytes(tail);
+            if (!binaryStreamOnly) {
+                request.writeBytes(tail);
+            }
             request.flush();
             request.close();
 


### PR DESCRIPTION
Hey @itinance,

This pull request fixes presigned s3 file upload. It basically fixes an oversight from #702.

Thanks ahead.