### PR TITLE
Fixing podpsec to reflect current git tagging scheme

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -13,9 +13,9 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.2'
 
-  s.source          = { :git => "https://github.com/itinance/react-native-fs", :tag => "#{s.version}" }
+  s.source          = { :git => "https://github.com/itinance/react-native-fs.git", :tag => "#{s.version}" }
   s.source_files    = '*.{h,m}'
   s.preserve_paths  = "**/*.js"
 
-  s.dependency 'React'
+  s.dependency 'React', '>= 0.59.5'
 end

--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.2'
 
-  s.source          = { :git => "https://github.com/itinance/react-native-fs", :tag => "v#{s.version}" }
+  s.source          = { :git => "https://github.com/itinance/react-native-fs", :tag => "#{s.version}" }
   s.source_files    = '*.{h,m}'
   s.preserve_paths  = "**/*.js"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs",
-  "version": "2.14.1",
+  "version": "2.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fix for #740. Changing the podspec to match the current tagging scheme. Also minor updates to reflect the current React dependency of the repo and resolve a pod warning about wanting `.git` in the GitHub URL.