### PR TITLE
RNFS.stopDownload never calls errorCallback()

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -154,15 +154,14 @@
             if (self->_params.resumableCallback) {
                 self->_params.resumableCallback();
             }
-            NSError *error = [NSError errorWithDomain:@"RNFS"
-                              code:0 //used to pass an NSString @"Aborted" here, but it needs an NSInteger
-                              userInfo:@{
-                              NSLocalizedDescriptionKey: @"Download has been aborted"
-            }];
-            self->_params.errorCallback(error);
-        } 
+        }
+        NSError *error = [NSError errorWithDomain:@"RNFS"
+                                  code:0 //used to pass an NSString @"Aborted" here, but it needs an NSInteger
+                                  userInfo:@{
+                                  NSLocalizedDescriptionKey: @"Download has been aborted"
+        }];
+        self->_params.errorCallback(error);
     }];
-
   }
 }
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -154,15 +154,13 @@
             if (self->_params.resumableCallback) {
                 self->_params.resumableCallback();
             }
-        } else {
             NSError *error = [NSError errorWithDomain:@"RNFS"
-                                                 code:0 //used to pass an NSString @"Aborted" here, but it needs an NSInteger
-                                             userInfo:@{
-                                                        NSLocalizedDescriptionKey: @"Download has been aborted"
-                                                        }];
-
+                              code:0 //used to pass an NSString @"Aborted" here, but it needs an NSInteger
+                              userInfo:@{
+                              NSLocalizedDescriptionKey: @"Download has been aborted"
+            }];
             self->_params.errorCallback(error);
-        }
+        } 
     }];
 
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:itinance/react-native-fs.git"
+    "url": "git@github.com:michaelmeyers/react-native-fs.git"
   },
   "keywords": [
     "react-component",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:michaelmeyers/react-native-fs.git"
+    "url": "git@github.com:itinance/react-native-fs.git"
   },
   "keywords": [
     "react-component",


### PR DESCRIPTION
## Issue

##### Related Issues: [#781](https://github.com/itinance/react-native-fs/issues/781),  [#638](https://github.com/itinance/react-native-fs/issues/638), [#568](https://github.com/itinance/react-native-fs/issues/568),

When running RNFS.stopDownload a callBack with the information that the download has been terminated is never sent. 
iOS appears to never return nil for this function `cancelByProducingResumeData(void (^)(NSData*resumeData))completionHandler`
If this function does not return nil, when the developer does not want/need the download to be resumable, the errorCallback() will never get called.

	@Downloader.m
	
	...
	- (void)stopDownload
	{
	  if (_task.state == NSURLSessionTaskStateRunning) {
	    [_task cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
	        if (resumeData != nil) {
	            self.resumeData = resumeData;
	            if (self->_params.resumableCallback) {
	                self->_params.resumableCallback();
	            }
	        } else {
	            NSError *error = [NSError errorWithDomain:@"RNFS"
	                              code:0 //used to pass an NSString @"Aborted" here, but it needs an NSInteger
	                              userInfo:@{
	                              NSLocalizedDescriptionKey: @"Download has been aborted"
	            }];
	            self->_params.errorCallback(error);
	        }
	    }];
	  }
	}
	...


##### Environment:
	System:
	    OS: macOS Mojave 10.14.6
	    CPU: (8) x64 Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
	    Memory: 80.18 MB / 16.00 GB
	    Shell: 3.2.57 - /bin/bash
	  Binaries:
	    Node: 11.2.0 - /usr/local/bin/node
	    npm: 6.4.1 - /usr/local/bin/npm
	    Watchman: 4.9.0 - /usr/local/bin/watchman
	  SDKs:
	    iOS SDK:
	      Platforms: iOS 13.2, DriverKit 19.0, macOS 10.15, tvOS 13.2, watchOS 6.1
	  IDEs:
	    Xcode: 11.3/11C29 - /usr/bin/xcodebuild
	  npmPackages:
	    react: 16.9.0 => 16.9.0 
	    react-native: 0.61.4 => 0.61.4
	    react-native-fs: 2.14.1
	  npmGlobalPackages:
	    react-native-cli: 2.0.1
	    react-native: 0.59.8

## Solution
It doesn't appear that the errorCallback() and the resumableCallback() need to be mutually exclusive. My fix removes the else and always called the errorCallBack().

	Downloader.m
	
	...
	- (void)stopDownload
	{
	  if (_task.state == NSURLSessionTaskStateRunning) {
	    [_task cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
	      NSLog(@"RNFS.stopDownload");
	        if (resumeData != nil) {
	            NSLog(@"RNFS.stopDownload resumeData does not equal nil");
	            self.resumeData = resumeData;
	            if (self->_params.resumableCallback) {
	                self->_params.resumableCallback();
	            }
	        }
	        NSError *error = [NSError errorWithDomain:@"RNFS"
	                                  code:0 //used to pass an NSString @"Aborted" here, but it needs an NSInteger
	                                  userInfo:@{
	                                  NSLocalizedDescriptionKey: @"Download has been aborted"
	        }];
	        NSLog(@"RNFS.stopDownload send terminated error");
	        self->_params.errorCallback(error);
	    }];
	  }
	}
	...

The error being passed states "Download has been aborted" and whether there is resumableData or not, the @Aborted error should be thrown.