### PR TITLE
Change react-native version in peerDependencies to 0.61.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react-native": "^0.59.5",
+    "react-native": "^0.61.0",
     "react-native-windows": "^0.57.2"
   }
 }


### PR DESCRIPTION
When installing the newest version of `react-native-fs` in project that runs on React Native 0.61.4 (Expo 36), I was seeing this warning: 
```console
npm WARN react-native-fs@2.16.2 requires a peer of react-native@^0.59.5 but none is installed. You must install peer dependencies yourself.
```
After changing this version of React Native in peer dependencies to `0.61.0`, according to README, this warning is gone.