### PR TITLE
Adds GetType For Android To Inspect Mine Type

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -306,6 +306,16 @@ var RNFS = {
     });
   },
 
+  // Android-only
+  getType(filepath: string): Promise<TypeResult> {
+    return RNFSManager.getType(filepath).then((result) => {
+      console.log(result)
+      return {
+        'type': result && result.type || '',
+      }
+    });
+  },
+
   readFile(filepath: string, encodingOrOptions?: any): Promise<string> {
     return readFileGeneric(filepath, encodingOrOptions, RNFSManager.readFile);
   },

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -11,6 +11,7 @@ import android.provider.MediaStore;
 import android.util.Base64;
 import android.util.SparseArray;
 import android.media.MediaScannerConnection;
+import android.net.Uri;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -638,6 +639,19 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     } catch (Exception ex) {
       ex.printStackTrace();
       reject(promise, filepath, ex);
+    }
+  }
+
+  @ReactMethod
+  public void getType(String filepath, Promise promise) {
+    try {
+      String type = reactContext.getContentResolver().getType(Uri.parse(filepath));
+      WritableMap map = Arguments.createMap();
+      map.putString("type", type);
+      promise.resolve(map);
+    } catch (Exception exception) {
+      exception.printStackTrace();
+      reject(promise, filepath, exception);
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,10 @@ type StatResult = {
 	isDirectory: () => boolean // Is the file a directory?
 }
 
+type TypeResult = {
+	type: string
+}
+
 type Headers = { [name: string]: string }
 type Fields = { [name: string]: string }
 
@@ -175,6 +179,11 @@ export function setReadable(
 ): Promise<boolean>
 
 export function stat(filepath: string): Promise<StatResult>
+
+/**
+ * Android-only
+ */
+export function getType(filepath: string): Promise<TypeResult>
 
 export function readFile(
 	filepath: string,


### PR DESCRIPTION
Given how Android passes around content uris, it’s not
easy to determine the actual path or extension.
But with the content resolver, one can easily query the
mine type. For this purpose, this adds a getType function
for Android only.