### PR TITLE
writeFile() not truncating file contents on Android 10

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -118,7 +118,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     Uri uri = getFileUri(filepath, false);
     OutputStream stream;
     try {
-      stream = reactContext.getContentResolver().openOutputStream(uri, append ? "wa" : "w");
+      stream = reactContext.getContentResolver().openOutputStream(uri, append ? "wa" : "wt");
     } catch (FileNotFoundException ex) {
       throw new IORejectionException("ENOENT", "ENOENT: " + ex.getMessage() + ", open '" + filepath + "'");
     }


### PR DESCRIPTION
Fix for #700 
As of Android 10, passing just "w" will no longer truncate the file after writing. You must also explicitly pass the truncate option. Previous versions of android treated "w" and "wt" as the same.

Changes:
- send write/truncate option as the mode to openOutputStream on Android when append is false.