### PR TITLE
add condition inside download event, before pass it to event callback.

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -500,15 +500,21 @@ var RNFS = {
     var subscriptions = [];
 
     if (options.begin) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', options.begin));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', (res) => {
+        if (res.jobId === jobId) options.begin(res);
+      }));
     }
 
     if (options.progress) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', options.progress));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', (res) => {
+        if (res.jobId === jobId) options.progress(res);
+      }));
     }
 
     if (options.resumable) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', options.resumable));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', (res) => {
+        if (res.jobId === joibId) options.resumable(res);
+      }));
     }
 
     var bridgeOptions = {


### PR DESCRIPTION
Related issue: https://github.com/itinance/react-native-fs/issues/811

**Problem**
When I called multiple `RNFS.downloadFile`, `begin` and `progress` callbacks return all events that occur, not only event that related to that instance only.

For example, I have 2 download process with jobId 1 and 2. In `begin` callback I'll receive responses of jobId 1 and 2, also in the `progress` callback.

**Solution**
When I check the native code there is nothing wrong with that, so I add conditions in event listener to check jobId before pass it event callback.

```javascript
    if (options.begin) {
      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', (res) => {
        if (res.jobId === jobId) options.begin(res);
      }));
    }

    if (options.progress) {
      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', (res) => {
        if (res.jobId === jobId) options.progress(res);
      }));
    }

    if (options.resumable) {
      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', (res) => {
        if (res.jobId === joibId) options.resumable(res);
      }));
    }
```