### PR TITLE
Fix flow errors and typo

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -501,19 +501,19 @@ var RNFS = {
 
     if (options.begin) {
       subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadBegin', (res) => {
-        if (res.jobId === jobId) options.begin(res);
+        if (res.jobId === jobId && options.begin) options.begin(res);
       }));
     }
 
     if (options.progress) {
       subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadProgress', (res) => {
-        if (res.jobId === jobId) options.progress(res);
+        if (res.jobId === jobId && options.progress) options.progress(res);
       }));
     }
 
     if (options.resumable) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', (res) => {
-        if (res.jobId === joibId) options.resumable(res);
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('DownloadResumable', () => {
+        if (options.resumable) options.resumable();
       }));
     }
 


### PR DESCRIPTION
- Flow is expecting that the `resumable` callback doesn't accept arguments.  As the event sent by the native code doesn't send a payload either, this should be reflected here.
- Flow is complaining about the callbacks possibly being undefined.  This is because, as far as flow knows, between the time that the callback is set-up and the callback is fired the callback could be undef (as is according to the flowtype definition).  Therefore, it needs to be checked at BOTH at the time the callback is setup, and at the time the callback is fired.
- `joibId` is a typo, but is not needed since there isn't ever a jobId in the resumable callback.

NOTE: I'm using versions:
```
"flow-bin": "~0.105.0",
"flow-typed": "^2.5.1",
"react-native": "0.61.5",
```