### PR TITLE
Binary only stream file length regression

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -564,14 +564,18 @@ var RNFS = {
     if (options.method && typeof options.method !== 'string') throw new Error('uploadFiles: Invalid value for property `method`');
 
     if (options.begin) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.begin));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', (res) => {
+        if (res.jobId === jobId) options.begin(res);
+      }));
     } else if (options.beginCallback) {
       // Deprecated
       subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.beginCallback));
     }
 
     if (options.progress) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progress));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', (res) => {
+        if (res.jobId === jobId) options.progress(res);
+      }));
     } else if (options.progressCallback) {
       // Deprecated
       subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progressCallback));

--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -117,11 +117,11 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
             if (mParams.onUploadBegin != null) {
                 mParams.onUploadBegin.onUploadBegin();
             }
+            long requestLength = totalFileLength;
+            connection.setFixedLengthStreamingMode((int)requestLength);
             if (!binaryStreamOnly) {
-                long requestLength = totalFileLength;
                 requestLength += stringData.length() + files.length * crlf.length();
                 connection.setRequestProperty("Content-length", "" +(int) requestLength);
-                connection.setFixedLengthStreamingMode((int)requestLength);
             }
             connection.connect();
 


### PR DESCRIPTION
This fixes an issue with progress update events not matching the jobId.  And a regression that occurred when the binaryonlystream option was added on Android.  The request length was changed to being set only when in not in binarystream mode. This caused the progress events to pile up waiting for the file to completely upload and large file size uploads to fail uploading entirely.