### PR TITLE
fix: add application support path for ios

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -621,6 +621,7 @@ var RNFS = {
   ExternalCachesDirectoryPath: RNFSManager.RNFSExternalCachesDirectoryPath,
   DocumentDirectoryPath: RNFSManager.RNFSDocumentDirectoryPath,
   DownloadDirectoryPath: RNFSManager.RNFSDownloadDirectoryPath,
+  ApplicationSupportDirectoryPath: RNFSManager.RNFSApplicationSupportDirectoryPath,
   ExternalDirectoryPath: RNFSManager.RNFSExternalDirectoryPath,
   ExternalStorageDirectoryPath: RNFSManager.RNFSExternalStorageDirectoryPath,
   TemporaryDirectoryPath: RNFSManager.RNFSTemporaryDirectoryPath,

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -960,6 +960,7 @@ RCT_EXPORT_METHOD(touch:(NSString*)filepath
 {
   return @{
            @"RNFSMainBundlePath": [[NSBundle mainBundle] bundlePath],
+           @"RNFSApplicationSupportDirectoryPath": [self getPathForDirectory:NSApplicationSupportDirectory],
            @"RNFSCachesDirectoryPath": [self getPathForDirectory:NSCachesDirectory],
            @"RNFSDocumentDirectoryPath": [self getPathForDirectory:NSDocumentDirectory],
            @"RNFSExternalDirectoryPath": [NSNull null],


### PR DESCRIPTION
## Summary

Adding the Application Support directory path to RNFS (addresses https://github.com/itinance/react-native-fs/issues/628)