### PR TITLE
Handle filename with spaces

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -27,7 +27,7 @@ var getJobId = () => {
   return jobId;
 };
 
-var normalizeFilePath = (path: string) => (path.startsWith('file://') ? path.slice(7) : path);
+var normalizeFilePath = (path: string) => (path.startsWith('file://') ? decodeURI(path).slice(7) : path);
 
 type MkdirOptions = {
   NSURLIsExcludedFromBackupKey?: boolean; // iOS only


### PR DESCRIPTION
On iOS, when the file path contains spaces, such as `file://abc/xyz%20123.jpg`, the normalize logic will just strip the first 7 characters and return `/abc/xyz%20123.jpg`. However, it should be`/abc/xyz 123.jpg` since the original file path is URI encoded. So we URI decode the file path before stripping.