### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files    = '*.{h,m}'
   s.preserve_paths  = "**/*.js"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116