### PR TITLE
Manually flush & invalidate session upon completion 

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -128,6 +128,14 @@
     NSLog(@"RNFS download: unable to move tempfile to destination. %@, %@", error, error.userInfo);
   }
 
+  // When numerous downloads are called the sessions are not always invalidated and cleared by iOS14. 
+  // This leads to error 28 – no space left on device so we manually flush and invalidate to free up space
+  if(session != nil){
+    [session flushWithCompletitonHandler:^{
+      [session finishTasksAndInvalidate];
+    }];
+  }
+
   return _params.completeCallback(_statusCode, _bytesWritten);
 }
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -133,7 +133,9 @@
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-  if (error && error.code != NSURLErrorCancelled) {
+  if (error) {
+     NSLog(@"RNFS download: didCompleteWithError %@, %@", error, error.userInfo);
+     if(error.code != NSURLErrorCancelled){
       _resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData];
       if (_resumeData != nil) {
         if (_params.resumableCallback) {
@@ -142,6 +144,7 @@
       } else {
           _params.errorCallback(error);
       }
+     }
   }
 }
 


### PR DESCRIPTION
Our application downloads ~1000 items from an API ranging from sizes of 2mb - 100mb, while doing so on iOS14 the device regularly returned `error 28 - no space left on device` 

We raised an issue (#937) and while investigating a fix we discovered that this error doesn't always mean the literal – https://github.com/AFNetworking/AFNetworking/issues/4313#issuecomment-437216801 

Since the library creates a new instance of Downloader per file download we've come to a conclusion that iOS14 doesn't flush the URLSessions quick enough when they're complete so we've added this manually.