### PR TITLE
Use getErrorStream() if status code is >= 400 in uploadFiles

### DIFF
--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -165,7 +165,14 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
             request.flush();
             request.close();
 
-            responseStream = new BufferedInputStream(connection.getInputStream());
+            statusCode = connection.getResponseCode();
+
+            if (statusCode >= 400) {
+                responseStream = new BufferedInputStream(connection.getErrorStream());
+            } else {
+                responseStream = new BufferedInputStream(connection.getInputStream());
+            }
+
             responseStreamReader = new BufferedReader(new InputStreamReader(responseStream));
             WritableMap responseHeaders = Arguments.createMap();
             Map<String, List<String>> map = connection.getHeaderFields();
@@ -181,7 +188,6 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
             }
 
             String response = stringBuilder.toString();
-            statusCode = connection.getResponseCode();
             res.headers = responseHeaders;
             res.body = response;
             res.statusCode = statusCode;


### PR DESCRIPTION
The current state of the Java Uploader is to always use `connection.getInputStream()` for any response in the `RNFS.uploadFiles`.

This behavior makes handling the different status code or any error message inside the response body impossible. 

In my use case, the server would send status code `500` if I uploaded the wrong file type, but if we use `connection.getInputStream()` when the server returns `>= 400` status code, `ENOENT` error will happen.

To fix this, we use `connection.getErrorStream()` whenever the server returns `>= 400` status code.


Disclaimer: I am not experienced in Java programming, please help me to review or improve anything there is to improve.