### PR TITLE
Add condition inside upload event before passing it to the event call…

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -564,17 +564,25 @@ var RNFS = {
     if (options.method && typeof options.method !== 'string') throw new Error('uploadFiles: Invalid value for property `method`');
 
     if (options.begin) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.begin));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', (res) => {
+        if (res.jobId === jobId) options.begin(res);
+      }));
     } else if (options.beginCallback) {
       // Deprecated
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.beginCallback));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', (res) => {
+        if (res.jobId === jobId) options.beginCallback(res);
+      }));
     }
-
+  
     if (options.progress) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progress));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', (res) => {
+        if (res.jobId === jobId) options.progress(res);
+      }));
     } else if (options.progressCallback) {
       // Deprecated
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progressCallback));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', (res) => {
+        if (res.jobId === jobId) options.progressCallback(res);
+      }));
     }
 
     var bridgeOptions = {


### PR DESCRIPTION
…back.

Similar issue: [#811](https://github.com/itinance/react-native-fs/issues/811)
Similar issue found for the `downloadFile`, `begin` and `progress` callbacks, our issue was involving the `uploadFile` event however very similar logic has been applied for this solution.

Problem
When calling `uploadFile` multiple different times, the `begin` and `progress` callbacks return for all events and not just the event they relate too. 

Solution
Added a condition inside the event listener to validate the `jobId` before passing the event callback.