### PR TITLE
Fix copyAssetsFileIOS's image resizing option to resize to exact width and height

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -812,7 +812,7 @@ RCT_EXPORT_METHOD(copyAssetsFileIOS: (NSString *) imageUri
         imageOptions.resizeMode = PHImageRequestOptionsResizeModeNone;
     } else {
         targetSize = CGSizeApplyAffineTransform(size, CGAffineTransformMakeScale(scale, scale));
-        imageOptions.resizeMode = PHImageRequestOptionsResizeModeFast;
+        imageOptions.resizeMode = PHImageRequestOptionsResizeModeExact;
     }
 
     PHImageContentMode contentMode = PHImageContentModeAspectFill;


### PR DESCRIPTION
`copyAssetsFileIOS` accepts `width` and `height` and resizes image when copying from Camera Roll.

```
copyAssetsFileIOS(imageUri, destPath, width, height, scale, compression, resizeMode)
```

However currently it doesn't respect `width` and `height`, and copied image may or may not have width and height that match `width` and `height`. That's because `copyAssetsFileIOS` uses `PHImageRequestOptionsResizeModeFast` option which makes [`requestImageForAsset`](https://developer.apple.com/documentation/photokit/phimagemanager/1616964-requestimageforasset?language=objc) method [efficiently resize the image to a size similar to, or slightly larger than, the target size](https://developer.apple.com/documentation/photokit/phimagerequestoptionsresizemode).

https://github.com/itinance/react-native-fs/blob/f2f8f4a058cd9acfbcac3b8cf1e08fa1e9b09786/RNFSManager.m#L808-L816

This pull request changes the option from `PHImageRequestOptionsResizeModeFast` to `PHImageRequestOptionsResizeModeExact` which makes `requestImageForAsset` method resize the image to match the target size, i.e. `width` and `height`, exactly.