### PR TITLE
macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For RN >= 0.61 please install react-native-fs at version >= @2.16.0!
 
 View the changelog [here](https://github.com/itinance/react-native-fs/blob/master/CHANGELOG.md).
 
-## Usage (iOS)
+## Usage (iOS/macOS)
 
 First you need to install react-native-fs:
 

--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.2'
+  s.osx.deployment_target = '10.10'
 
   s.source          = { :git => "https://github.com/itinance/react-native-fs", :tag => "v#{s.version}" }
   s.source_files    = '*.{h,m}'

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -747,7 +747,7 @@ RCT_EXPORT_METHOD(getFSInfo:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromise
 
 
 // [PHAsset fetchAssetsWithALAssetURLs] is deprecated and not supported in Mac Catalyst
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_UIKITFORMAC && !TARGET_OS_OSX
 /**
  * iOS Only: copy images from the assets-library (camera-roll) to a specific path, asuming
  * JPEG-Images.
@@ -844,7 +844,7 @@ RCT_EXPORT_METHOD(copyAssetsFileIOS: (NSString *) imageUri
 #endif
 
 // [PHAsset fetchAssetsWithALAssetURLs] is deprecated and not supported in Mac Catalyst
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_UIKITFORMAC && !TARGET_OS_OSX
 /**
  * iOS Only: copy videos from the assets-library (camera-roll) to a specific path as mp4-file.
  *

--- a/Uploader.h
+++ b/Uploader.h
@@ -1,5 +1,8 @@
 #import <Foundation/Foundation.h>
+
+#if !TARGET_OS_OSX
 #import <MobileCoreServices/MobileCoreServices.h>
+#endif
 
 typedef void (^UploadCompleteCallback)(NSString*, NSURLResponse *);
 typedef void (^UploadErrorCallback)(NSError*);


### PR DESCRIPTION
Hi! This allows using `react-native-fs` on macOS.

I confirmed that it works with a react-native app for macOS based on https://microsoft.github.io/react-native-windows/.
Though I haven't used all of the API methods yet, just the basics like `readdir`, `readFile` and so on.

I didn't get the integration tests to build, but that is I think unrelated to my changes.