### PR TITLE
added mavenCentral() for gradle builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,7 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,6 @@ def safeExtGet(prop, fallback) {
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
As jCenter is shutting down so adding mavenCentral() so that gradle builds fail