### PR TITLE
remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,5 @@
     "create-react-class": "15.6.3",
     "flow-bin": "^0.109.0",
     "prop-types": "^15.7.2"
-  },
-  "peerDependencies": {
-    "react-native": "^0.59.5",
-    "react-native-windows": "^0.57.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,9 @@
     "create-react-class": "15.6.3",
     "flow-bin": "^0.109.0",
     "prop-types": "^15.7.2"
+  },
+  "peerDependencies": {
+    "react-native": "*",
+    "react-native-windows": "*"
   }
 }


### PR DESCRIPTION
remove `peerDependencies` from [package.json](https://github.com/itinance/react-native-fs/blob/master/package.json) because of `npm 7+ `
#997 