### PR TITLE
Improve encodingOrOptions type definition and update the doc

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -141,10 +141,12 @@ type FSInfoResult = {
   freeSpace: number;    // The amount of available storage space on the device (in bytes).
 };
 
+type EncodingOrOptions = 'utf8' | 'base64' | 'ascii' | Record<string, any>;
+
 /**
  * Generic function used by readFile and readFileAssets
  */
-function readFileGeneric(filepath: string, encodingOrOptions: ?string, command: Function) {
+function readFileGeneric(filepath: string, encodingOrOptions: ?EncodingOrOptions, command: Function) {
   var options = {
     encoding: 'utf8'
   };
@@ -306,11 +308,11 @@ var RNFS = {
     });
   },
 
-  readFile(filepath: string, encodingOrOptions?: any): Promise<string> {
+  readFile(filepath: string, encodingOrOptions?: EncodingOrOptions): Promise<string> {
     return readFileGeneric(filepath, encodingOrOptions, RNFSManager.readFile);
   },
 
-  read(filepath: string, length: number = 0, position: number = 0, encodingOrOptions?: any): Promise<string> {
+  read(filepath: string, length: number = 0, position: number = 0, encodingOrOptions?: EncodingOrOptions): Promise<string> {
     var options = {
       encoding: 'utf8'
     };
@@ -341,7 +343,7 @@ var RNFS = {
   },
 
   // Android only
-  readFileAssets(filepath: string, encodingOrOptions?: any): Promise<string> {
+  readFileAssets(filepath: string, encodingOrOptions?: EncodingOrOptions): Promise<string> {
     if (!RNFSManager.readFileAssets) {
       throw new Error('readFileAssets is not available on this platform');
     }
@@ -349,7 +351,7 @@ var RNFS = {
   },
 
   // Android only
-  readFileRes(filename: string, encodingOrOptions?: any): Promise<string> {
+  readFileRes(filename: string, encodingOrOptions?: EncodingOrOptions): Promise<string> {
     if (!RNFSManager.readFileRes) {
       throw new Error('readFileRes is not available on this platform');
     }
@@ -393,7 +395,7 @@ var RNFS = {
     return RNFSManager.copyAssetsVideoIOS(imageUri, destPath);
   },
 
-  writeFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
+  writeFile(filepath: string, contents: string, encodingOrOptions?: EncodingOrOptions): Promise<void> {
     var b64;
 
     var options = {
@@ -424,7 +426,7 @@ var RNFS = {
     return RNFSManager.writeFile(normalizeFilePath(filepath), b64, options).then(() => void 0);
   },
 
-  appendFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
+  appendFile(filepath: string, contents: string, encodingOrOptions?: EncodingOrOptions): Promise<void> {
     var b64;
 
     var options = {
@@ -452,7 +454,7 @@ var RNFS = {
     return RNFSManager.appendFile(normalizeFilePath(filepath), b64);
   },
 
-  write(filepath: string, contents: string, position?: number, encodingOrOptions?: any): Promise<void> {
+  write(filepath: string, contents: string, position?: number, encodingOrOptions?: EncodingOrOptions): Promise<void> {
     var b64;
 
     var options = {

--- a/README.md
+++ b/README.md
@@ -383,43 +383,43 @@ type StatResult = {
 };
 ```
 
-### `readFile(filepath: string, encoding?: string): Promise<string>`
+### `readFile(filepath: string, encodingOrOptions?: 'utf8' | 'base64' | 'ascii' | object): Promise<string>`
 
-Reads the file at `path` and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+Reads the file at `path` and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files. `options` optionally takes an object specifying the file's properties, like mode etc.
 
 Note: you will take quite a performance hit if you are reading big files
 
-### `read(filepath: string, length = 0, position = 0, encodingOrOptions?: any): Promise<string>`
+### `read(filepath: string, length = 0, position = 0, encodingOrOptions?: 'utf8' | 'base64' | 'ascii' | object): Promise<string>`
 
-Reads `length` bytes from the given `position` of the file at `path` and returns contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+Reads `length` bytes from the given `position` of the file at `path` and returns contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files. `options` optionally takes an object specifying the file's properties, like mode etc.
 
 Note: reading big files piece by piece using this method may be useful in terms of performance.
 
-### `readFileAssets(filepath:string, encoding?: string): Promise<string>`
+### `readFileAssets(filepath:string, encodingOrOptions?: 'utf8' | 'base64' | 'ascii' | object): Promise<string>`
 
-Reads the file at `path` in the Android app's assets folder and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+Reads the file at `path` in the Android app's assets folder and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files. `options` optionally takes an object specifying the file's properties, like mode etc.
 
 `filepath` is the relative path to the file from the root of the `assets` folder.
 
 Note: Android only.
 
-### `readFileRes(filename:string, encoding?: string): Promise<string>`
+### `readFileRes(filename:string, encodingOrOptions?: 'utf8' | 'base64' | 'ascii' | object): Promise<string>`
 
-Reads the file named `filename` in the Android app's `res` folder and return contents. Only the file name (not folder) needs to be specified. The file type will be detected from the extension and automatically located within `res/drawable` (for image files) or `res/raw` (for everything else). `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+Reads the file named `filename` in the Android app's `res` folder and return contents. Only the file name (not folder) needs to be specified. The file type will be detected from the extension and automatically located within `res/drawable` (for image files) or `res/raw` (for everything else). `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files. `options` optionally takes an object specifying the file's properties, like mode etc.
 
 Note: Android only.
 
-### `writeFile(filepath: string, contents: string, encoding?: string): Promise<void>`
+### `writeFile(filepath: string, contents: string, encodingOrOptions?: 'utf8' | 'base64' | 'ascii' | object): Promise<void>`
 
 Write the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`. `options` optionally takes an object specifying the file's properties, like mode etc.
 
-### `appendFile(filepath: string, contents: string, encoding?: string): Promise<void>`
+### `appendFile(filepath: string, contents: string, encodingOrOptions?: 'utf8' | 'base64' | 'ascii' | object): Promise<void>`
 
-Append the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`.
+Append the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`. `options` optionally takes an object specifying the file's properties, like mode etc.
 
-### `write(filepath: string, contents: string, position?: number, encoding?: string): Promise<void>`
+### `write(filepath: string, contents: string, position?: number, encodingOrOptions?: 'utf8' | 'base64' | 'ascii' | object): Promise<void>`
 
-Write the `contents` to `filepath` at the given random access position. When `position` is `undefined` or `-1` the contents is appended to the end of the file. `encoding` can be one of `utf8` (default), `ascii`, `base64`.
+Write the `contents` to `filepath` at the given random access position. When `position` is `undefined` or `-1` the contents is appended to the end of the file. `encoding` can be one of `utf8` (default), `ascii`, `base64`. `options` optionally takes an object specifying the file's properties, like mode etc.
 
 ### `moveFile(filepath: string, destPath: string): Promise<void>`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,6 +110,8 @@ type FSInfoResult = {
 	freeSpace: number // The amount of available storage space on the device (in bytes).
 }
 
+type EncodingOrOptions = 'utf8' | 'base64' | 'ascii' | Record<string, any>;
+
 export function mkdir(filepath: string, options?: MkdirOptions): Promise<void>
 export function moveFile(
 	filepath: string,
@@ -178,13 +180,13 @@ export function stat(filepath: string): Promise<StatResult>
 
 export function readFile(
 	filepath: string,
-	encodingOrOptions?: any
+	encodingOrOptions?: EncodingOrOptions
 ): Promise<string>
 export function read(
 	filepath: string,
 	length?: number,
 	position?: number,
-	encodingOrOptions?: any
+	encodingOrOptions?: EncodingOrOptions
 ): Promise<string>
 
 /**
@@ -200,7 +202,7 @@ export function readFileAssets(
  */
 export function readFileRes(
 	filepath: string,
-	encodingOrOptions?: any
+	encodingOrOptions?: EncodingOrOptions
 ): Promise<string>
 
 export function hash(filepath: string, algorithm: string): Promise<string>
@@ -251,20 +253,20 @@ export function copyAssetsVideoIOS(
 export function writeFile(
 	filepath: string,
 	contents: string,
-	encodingOrOptions?: any
+	encodingOrOptions?: EncodingOrOptions
 ): Promise<void>
 
 export function appendFile(
 	filepath: string,
 	contents: string,
-	encodingOrOptions?: string
+	encodingOrOptions?: EncodingOrOptions
 ): Promise<void>
 
 export function write(
 	filepath: string,
 	contents: string,
 	position?: number,
-	encodingOrOptions?: any
+	encodingOrOptions?: EncodingOrOptions
 ): Promise<void>
 
 export function downloadFile(


### PR DESCRIPTION
Including in this PR:

- Improve typescript and flow type definition for `encodingOrOptions`. Changing the type definition from `any` to an union type of encoding string (one of ascii, base64 or utf8) and object.

- Upgrade document for `readFile`, `read`, `readFileAssets`, `readFileRes`, `writeFile`, `appendFile` and `write` to reflect the type definition change and to make them up-to-date with the implementation in FS.common.js.