### PR TITLE
make react-native-windows peer dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
   "peerDependencies": {
     "react-native": "*",
     "react-native-windows": "*"
+  },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
> As of npm v7, peerDependencies are installed by default.
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies