### PR TITLE
fix: addListener and removeListeners methods wass added to pass warning with Native Event Emitter 

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -949,6 +949,17 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     );
   }
 
+  // Required for rn built in EventEmitter Calls.
+  @ReactMethod
+  public void addListener(String eventName) {
+
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+
+  }
+
   private void reject(Promise promise, String filepath, Exception ex) {
     if (ex instanceof FileNotFoundException) {
       rejectFileNotFound(promise, filepath);


### PR DESCRIPTION
While working with the module for uploading files to the server, I encountered the warnings given in the screenshots: [in Metro](https://i.imgur.com/yuegCPA.png); [in_app_1](https://i.imgur.com/fnVzjkL.jpeg); [in_app_2](https://i.imgur.com/ZEIAEvL.jpeg); [in_app_3](https://i.imgur.com/xNWqb9c.jpeg)
They did not interfere with the operation of the module, but they were very annoying.
I'm not very good at java and writing native modules, but based on the solution i found in the reanimated: [this fix](https://github.com/software-mansion/react-native-reanimated/pull/2316/files#diff-791d943e777c3aeed7f019e3261ef3f1447da24e60c47d7cc90f5d520121a00d). I added the required methods to the RNFSManager.