### PR TITLE
Fix types for UploadFileItem

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,10 +82,10 @@ type UploadFileOptions = {
 }
 
 type UploadFileItem = {
-	name: string // Name of the file, if not defined then filename is used
+	name?: string // Name of the file, if not defined then filename is used
 	filename: string // Name of file
 	filepath: string // Path to file
-	filetype: string // The mimetype of the file to be uploaded, if not defined it will get mimetype from `filepath` extension
+	filetype?: string // The mimetype of the file to be uploaded, if not defined it will get mimetype from `filepath` extension
 }
 
 type UploadBeginCallbackResult = {


### PR DESCRIPTION
Documentation states that name and filetype are not required. Update types accordingly.