### PR TITLE
fix: use correct type for stat size

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ type ReadDirItem = {
 	mtime: Date | undefined // The last modified date of the file
 	name: string // The name of the item
 	path: string // The absolute path to the item
-	size: string // Size in bytes
+	size: number // Size in bytes
 	isFile: () => boolean // Is the file just a file?
 	isDirectory: () => boolean // Is the file a directory?
 }
@@ -20,7 +20,7 @@ type ReadDirItem = {
 type StatResult = {
 	name: string | undefined // The name of the item TODO: why is this not documented?
 	path: string // The absolute path to the item
-	size: string // Size in bytes
+	size: number // Size in bytes
 	mode: number // UNIX file mode
 	ctime: number // Created date
 	mtime: number // Last modified date


### PR DESCRIPTION
Hey. I console.log'd a list of files I got from `fs.readDir()` and to me it looks like the `size` property is of type `number`, not `string`:
```
{
    "ctime": "2021-10-19T16:02:30.807Z",
    "mtime": "2021-10-19T16:02:35.146Z",
    "name": "B1979F99-6369-4036-8476-B6D14E653B0E.mp4",
    "path": "/private/var/mobile/Containers/Data/Application/0CE5748F-79A8-4120-B366-C92E6E0C6D17/tmp/ReactNative/B1979F99-6369-4036-8476-B6D14E653B0E.mp4",
    "size": 34234799,
}
```

Could you please check and verify/falsify that?