### PR TITLE
Fix progressCallback not get called when call downloadFile on iOS platform

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -75,9 +75,11 @@
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)downloadTask.response;
-  if (_params.beginCallback && !_statusCode) {
-    _statusCode = [NSNumber numberWithLong:httpResponse.statusCode];
-    _contentLength = [NSNumber numberWithLong:httpResponse.expectedContentLength];
+  if (!_statusCode) {
+      _statusCode = [NSNumber numberWithLong:httpResponse.statusCode];
+      _contentLength = [NSNumber numberWithLong:httpResponse.expectedContentLength];
+  }
+  if (_params.beginCallback) {
     return _params.beginCallback(_statusCode, _contentLength, httpResponse.allHeaderFields);
   }
 


### PR DESCRIPTION
On iOS platform, when I call `downloadFile` method without setting the `begin` callback param, the `progress` callback not get called anyway.

In **Downloader.m**  file, `progressCallback` get called only when `statusCode` equal to 200, and `statusCode` is assigned value only when there is `beginCallback`.

So I put the `statusCode`'s assigning before `beginCallback`'s determination,  so that `statusCode` will be assigned value without  `beginCallback`.