### PR TITLE
fix readme href link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For RN >= 0.61 please install react-native-fs at version >= @2.16.0!
 ## Table of Contents
 1. [Changelog](#Changelog)
 1. Usage
-    1. [iOS](#usage-ios)
+    1. [iOS](#usage-iosmacos)
     1. [Android](#usage-android)
     1. [Windows](#usage-windows)
 1. [Examples](#Examples)


### PR DESCRIPTION
ios archor now is `#usage-iosmacos` not `#usage-ios`