### PR TITLE
Set Android uploader connection to fixed length streaming mode

### DIFF
--- a/android/src/main/java/com/rnfs/Uploader.java
+++ b/android/src/main/java/com/rnfs/Uploader.java
@@ -125,6 +125,9 @@ public class Uploader extends AsyncTask<UploadParams, int[], UploadResult> {
                 requestLength += stringData.length() + files.length * crlf.length();
                 connection.setRequestProperty("Content-length", "" +(int) requestLength);
                 connection.setFixedLengthStreamingMode((int)requestLength);
+            } else {
+                // ensure byteSentTotal sent in progress updates is accurate
+                connection.setFixedLengthStreamingMode((int)totalFileLength);
             }
             connection.connect();
 


### PR DESCRIPTION
Fixes https://github.com/itinance/react-native-fs/issues/1129

Ensure byteSentTotal sent in progress updates is accurate on Android when `binaryStreamOnly` is set to `true`.