### PR TITLE
ref: rename read function params

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -310,7 +310,7 @@ var RNFS = {
     return readFileGeneric(filepath, encodingOrOptions, RNFSManager.readFile);
   },
 
-  read(filepath: string, length: number = 0, position: number = 0, encodingOrOptions?: any): Promise<string> {
+  read(filepath: string, chunkLengthInBytes: number = 0, offsetInBytes: number = 0, encodingOrOptions?: any): Promise<string> {
     var options = {
       encoding: 'utf8'
     };
@@ -323,7 +323,7 @@ var RNFS = {
       }
     }
 
-    return RNFSManager.read(normalizeFilePath(filepath), length, position).then((b64) => {
+    return RNFSManager.read(normalizeFilePath(filepath), chunkLengthInBytes, offsetInBytes).then((b64) => {
       var contents;
 
       if (options.encoding === 'utf8') {

--- a/README.md
+++ b/README.md
@@ -390,9 +390,9 @@ Reads the file at `path` and return contents. `encoding` can be one of `utf8` (d
 
 Note: you will take quite a performance hit if you are reading big files
 
-### `read(filepath: string, length = 0, position = 0, encodingOrOptions?: any): Promise<string>`
+### `read(filepath: string, chunkLengthInBytes = 0, offsetInBytes = 0, encodingOrOptions?: any): Promise<string>`
 
-Reads `length` bytes from the given `position` of the file at `path` and returns contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+Reads `chunkLengthInBytes` from the given `offsetInBytes` of the file at `path` and returns contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
 
 Note: reading big files piece by piece using this method may be useful in terms of performance.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -182,8 +182,8 @@ export function readFile(
 ): Promise<string>
 export function read(
 	filepath: string,
-	length?: number,
-	position?: number,
+	chunkLengthInBytes?: number,
+	offsetInBytes?: number,
 	encodingOrOptions?: any
 ): Promise<string>
 


### PR DESCRIPTION
The `read` function params were superficial about what it was used for, i renamed them to be more clear about what is expected