### PR TITLE
feat: Handle 303 redirection

### DIFF
--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -67,6 +67,7 @@ public class Downloader extends AsyncTask<DownloadParams, long[], DownloadResult
         (
           statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
           statusCode == HttpURLConnection.HTTP_MOVED_TEMP ||
+          statusCode == HttpURLConnection.HTTP_SEE_OTHER ||
           statusCode == 307 ||
           statusCode == 308
         )


### PR DESCRIPTION
Since HttpURLConnection doesn't allow the redirection between http and https (https://developer.android.com/reference/java/net/HttpURLConnection.html#response-handling) we need to handle the redirection manually by getting the location, closing the current connexion and create a new one. 

We do that for almost all the 3xx response, but not for the 303. So, let's add it. 