### PR TITLE
Added pathForGroupSync method

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -213,6 +213,10 @@ var RNFS = {
     return RNFSManager.pathForGroup(groupName);
   },
 
+  pathForGroupSync(groupName: string): string {
+    return RNFSManager.pathForGroupSync(groupName);
+  },
+
   getFSInfo(): Promise<FSInfoResult> {
     return RNFSManager.getFSInfo();
   },

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -722,6 +722,11 @@ RCT_EXPORT_METHOD(pathForGroup:(nonnull NSString *)groupId
   }
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(pathForGroupSync:(nonnull NSString *)groupId) {
+  NSURL *groupURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier: groupId];
+  return [groupURL path];
+}
+
 RCT_EXPORT_METHOD(getFSInfo:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   unsigned long long totalSpace = 0;

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,6 +123,7 @@ export function copyFile(
 ): Promise<void>
 export function pathForBundle(bundleNamed: string): Promise<string>
 export function pathForGroup(groupName: string): Promise<string>
+export function pathForGroupSync(groupName: string): string
 export function getFSInfo(): Promise<FSInfoResult>
 export function getAllExternalFilesDirs(): Promise<string[]>
 export function unlink(filepath: string): Promise<void>


### PR DESCRIPTION
Added `pathForGroupSync` method to get `App Group Path` synchronously.

**pathForGroup:**
```js
const groupPath = await pathForGroup("group.xxx.com");
```

**pathForGroupSync:**
```js
const groupPath = pathForGroupSync("group.xxx.com");
```