### PR TITLE
Fix types for StatResult's ctime and mtime

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,8 +22,8 @@ type StatResult = {
 	path: string // The absolute path to the item
 	size: number // Size in bytes
 	mode: number // UNIX file mode
-	ctime: number // Created date
-	mtime: number // Last modified date
+	ctime: Date // Created date
+	mtime: Date // Last modified date
 	originalFilepath: string // In case of content uri this is the pointed file path, otherwise is the same as path
 	isFile: () => boolean // Is the file just a file?
 	isDirectory: () => boolean // Is the file a directory?


### PR DESCRIPTION
According to the [docs](https://github.com/itinance/react-native-fs#statfilepath-string-promisestatresult), type for `ctime` and `mtime` in `StatResult` should be `Date` not `number`.