### PR TITLE
sync FileOutputStream FD

### DIFF
--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -141,6 +141,7 @@ public class Downloader extends AsyncTask<DownloadParams, long[], DownloadResult
         }
 
         output.flush();
+        output.getFD().sync();
         res.bytesWritten = total;
       }
       res.statusCode = statusCode;


### PR DESCRIPTION
Call [sync](https://stackoverflow.com/questions/5650327/are-filechannel-force-and-filedescriptor-sync-both-needed) from FileOutputStream FD in order to avoid corrupt images just after download.