### PR TITLE
docs: Change return type Promise<void> to void from startUpload documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ type UploadProgressCallbackResult = {
 
 Percentage can be computed easily by dividing `totalBytesSent` by `totalBytesExpectedToSend`.
 
-### (iOS only) `stopUpload(jobId: number): Promise<void>`
+### (iOS only) `stopUpload(jobId: number): void`
 
 Abort the current upload job with this ID.
 


### PR DESCRIPTION
According to TS types and code, this method return `void` and not `Promise<void>`