### PR TITLE
fix: StatResult ctime type

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -54,7 +54,7 @@ type StatResult = {
   path: string;     // The absolute path to the item
   size: string;     // Size in bytes
   mode: number;     // UNIX file mode
-  ctime: number;    // Created date
+  ctime: Date;      // Created date
   mtime: number;    // Last modified date
   originalFilepath: string;    // In case of content uri this is the pointed file path, otherwise is the same as path
   isFile: () => boolean;        // Is the file just a file?

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ type StatResult = {
 	path: string // The absolute path to the item
 	size: number // Size in bytes
 	mode: number // UNIX file mode
-	ctime: number // Created date
+	ctime: Date // Created date
 	mtime: number // Last modified date
 	originalFilepath: string // In case of content uri this is the pointed file path, otherwise is the same as path
 	isFile: () => boolean // Is the file just a file?


### PR DESCRIPTION
This pull request fixes ctime type which is, in fact, a Date value, as evidenced in the `stat` implementation method:
- https://github.com/itinance/react-native-fs/blob/master/FS.common.js#L306C17-L306C17
```ts
type StatResult = {
  name: ?string;
  path: string;
  size: string;
  mode: number;
  ctime: number; // <-- Invalid type as shown in below stat method
};

// ...

stat(filepath: string): Promise<StatResult> {
  return RNFSManager.stat(normalizeFilePath(filepath)).then((result) => {
    return {
      'path': filepath,
      'ctime': new Date(result.ctime * 1000), // <-- ctime is a Date type, not a number
      ...
    };
  });
}
```