### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ The following constants are available on the `RNFS` export:
 - `PicturesDirectoryPath` (`String`) The absolute path to the pictures directory (Windows only)
 - `RoamingDirectoryPath` (`String`) The absolute path to the roaming directory (Windows only)
 
+**IMPORTANT**: `DocumentDirectoryPath` (iOS) will include an ID in the path that changes each build e.g `...Application/BCE32988-4C51-483B-892B-16671E3771C2/Documents`. 
+Use relative paths and resolve the full path at runtime to avoid files not being found on new builds.
 
 IMPORTANT: when using `ExternalStorageDirectoryPath` it's necessary to request permissions (on Android) to read and write on the external storage, here an example: [React Native Offical Doc](https://facebook.github.io/react-native/docs/permissionsandroid)
 


### PR DESCRIPTION
Write docs for issue #701

Update readme with notes about changing paths for DocumentDirectoryPath on iOS and advice use of relative paths or just filenames to resolve path at runtime

I got hit with this today wondering why my files didn't load that had been stored using absolute path (which is a mistake I know but still). I didn't notice the ID was changing on each build 
