### PR TITLE
fix: add jobId condition inside upload event

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -572,17 +572,25 @@ var RNFS = {
     if (options.method && typeof options.method !== 'string') throw new Error('uploadFiles: Invalid value for property `method`');
 
     if (options.begin) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.begin));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', (res) => {
+        if (res.jobId === jobId) options.begin(res);
+      }));
     } else if (options.beginCallback) {
       // Deprecated
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', options.beginCallback));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadBegin', (res) => {
+        if (res.jobId === jobId) options.beginCallback(res);
+      }));
     }
 
     if (options.progress) {
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progress));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', (res) => {
+        if (res.jobId === jobId) options.progress(res);
+      }));
     } else if (options.progressCallback) {
       // Deprecated
-      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', options.progressCallback));
+      subscriptions.push(RNFS_NativeEventEmitter.addListener('UploadProgress', (res) => {
+        if (res.jobId === jobId) options.progressCallback(res);
+      }));
     }
 
     var bridgeOptions = {


### PR DESCRIPTION
Hi, many thanks for this project!

**Problem that I encountered:**
When I called multiple `RNFS.uploadFiles` progress callbacks fire events for every upload started, not only event that related to that upload only.

If two uploads were started with `jobId` 1 and 2 - In progress callback I'll receive responses of `jobId` 1 and 2.

This patch is based on existing solution with `RNFS.downloadFile` progress callbacks and it helped me with this problem. 