### PR TITLE
feat: add visionOS support

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -9,10 +9,11 @@ Pod::Spec.new do |s|
   s.summary         = pjson["description"]
   s.license         = pjson["license"]
   s.author          = { "Johannes Lumpe" => "johannes@lum.pe" }
-  
+
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.2'
   s.osx.deployment_target = '10.10'
+  s.visionos.deployment_target = '1.0'
 
   s.source          = { :git => "https://github.com/itinance/react-native-fs", :tag => "v#{s.version}" }
   s.source_files    = '*.{h,m}'


### PR DESCRIPTION
Add support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

This only adds a new platform to the podspec, so the module can be installed in visionOS. No changes to any existing functionality.

![simulator_screenshot_318C06C2-2A88-40D8-A534-19ED0C70A111](https://github.com/itinance/react-native-fs/assets/26878038/da1b453d-3e5c-4b9c-805b-027843e40a39)
